### PR TITLE
Remove duplicate items

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,3 +31,17 @@ jobs:
   
     - name: Test
       run: go test -timeout 30s ./... -race
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build
+    steps:
+      # Creates a release and attaches
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     needs:
-      - build
+      - test
     steps:
       # Creates a release and attaches
       - name: Create Release

--- a/engine.go
+++ b/engine.go
@@ -363,24 +363,31 @@ func (e *Engine) Start() error {
 	// stored in a map for de-duplication before being subscribed to
 	subscriptionMap := make(map[string]bool)
 
+	// We need to track if we are making a wildcard subscription. If we are then
+	// there isn't any point making 10 subscriptions since they will be covered
+	// by the wildcard anyway and will end up being duplicates. In that case we
+	// should just be making the one
+	var wildcardExists bool
+
 	for _, src := range e.Sources() {
 		for _, itemContext := range src.Contexts() {
-			var subjectSuffix string
-
 			if itemContext == sdp.WILDCARD {
-				subjectSuffix = ">"
+				wildcardExists = true
 			} else {
-				subjectSuffix = itemContext
+				subscriptionMap[itemContext] = true
 			}
-
-			subscriptionMap[subjectSuffix] = true
 		}
 	}
 
 	// Now actually create the required subscriptions
-	for suffix := range subscriptionMap {
-		e.Subscribe(fmt.Sprintf("request.context.%v", suffix), e.ItemRequestHandler)
-		e.Subscribe(fmt.Sprintf("cancel.context.%v", suffix), e.CancelItemRequestHandler)
+	if wildcardExists {
+		e.Subscribe("request.context.>", e.ItemRequestHandler)
+		e.Subscribe("cancel.context.>", e.CancelItemRequestHandler)
+	} else {
+		for suffix := range subscriptionMap {
+			e.Subscribe(fmt.Sprintf("request.context.%v", suffix), e.ItemRequestHandler)
+			e.Subscribe(fmt.Sprintf("cancel.context.%v", suffix), e.CancelItemRequestHandler)
+		}
 	}
 
 	return nil

--- a/engine.go
+++ b/engine.go
@@ -159,7 +159,7 @@ func (e *Engine) AddSources(sources ...Source) {
 			return iSource.Weight() > jSource.Weight()
 		})
 
-		e.sourceMap[src.Type()] = append(e.sourceMap[src.Type()], src)
+		e.sourceMap[src.Type()] = allSources
 	}
 }
 
@@ -470,6 +470,11 @@ func (e *Engine) CancelItemRequestHandler(cancelRequest *sdp.CancelItemRequest) 
 		}).Debug("Cancelling request")
 		rt.Cancel()
 	}
+}
+
+// ClearCache Completely clears the cache
+func (e *Engine) ClearCache() {
+	e.cache.Clear()
 }
 
 // IsWildcard checks if a string is the wildcard. Use this instead of

--- a/engine_test.go
+++ b/engine_test.go
@@ -195,7 +195,7 @@ func TestNats(t *testing.T) {
 		req := sdp.ItemRequest{
 			Type:            "person",
 			Method:          sdp.RequestMethod_GET,
-			Query:           "dylan",
+			Query:           "basic",
 			LinkDepth:       0,
 			Context:         "test",
 			ResponseSubject: NewResponseSubject(),
@@ -221,7 +221,7 @@ func TestNats(t *testing.T) {
 		req := sdp.ItemRequest{
 			Type:            "person",
 			Method:          sdp.RequestMethod_GET,
-			Query:           "dylan",
+			Query:           "deeplink",
 			LinkDepth:       10,
 			Context:         "test",
 			ResponseSubject: NewResponseSubject(),
@@ -234,8 +234,8 @@ func TestNats(t *testing.T) {
 			t.Error(err)
 		}
 
-		if len(src.GetCalls) != 10 {
-			t.Errorf("expected 10 get calls, got %v: %v", len(src.GetCalls), src.GetCalls)
+		if len(src.GetCalls) != 11 {
+			t.Errorf("expected 11 get calls, got %v: %v", len(src.GetCalls), src.GetCalls)
 		}
 	})
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -160,7 +160,14 @@ func TestNats(t *testing.T) {
 
 	src := TestSource{}
 
-	e.AddSources(&src)
+	e.AddSources(
+		&src,
+		&TestSource{
+			ReturnContexts: []string{
+				sdp.WILDCARD,
+			},
+		},
+	)
 
 	t.Run("Starting", func(t *testing.T) {
 		err := e.Connect()
@@ -173,6 +180,10 @@ func TestNats(t *testing.T) {
 
 		if err != nil {
 			t.Error(err)
+		}
+
+		if len(e.subscriptions) != 4 {
+			t.Errorf("Expected engine to have 4 subscriptions, got %v", len(e.subscriptions))
 		}
 	})
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -190,6 +190,7 @@ func TestNats(t *testing.T) {
 	t.Run("Handling a basic request", func(t *testing.T) {
 		t.Cleanup(func() {
 			src.ClearCalls()
+			e.ClearCache()
 		})
 
 		req := sdp.ItemRequest{
@@ -216,6 +217,7 @@ func TestNats(t *testing.T) {
 	t.Run("Handling a deeply linking request", func(t *testing.T) {
 		t.Cleanup(func() {
 			src.ClearCalls()
+			e.ClearCache()
 		})
 
 		req := sdp.ItemRequest{

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/nats-io/nats.go v1.13.1-0.20211122170419-d7c1d78a50fc
 	github.com/overmindtech/sdp-go v0.6.1
-	github.com/overmindtech/sdpcache v0.1.4
+	github.com/overmindtech/sdpcache v0.2.0
 	github.com/sirupsen/logrus v1.8.1
 	google.golang.org/protobuf v1.27.1
 )
@@ -21,7 +21,7 @@ require (
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
-	golang.org/x/sys v0.0.0-20220111092808-5a964db01320 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/time v0.0.0-20211116232009-f0f3c7e86c11 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect

--- a/requests.go
+++ b/requests.go
@@ -247,6 +247,10 @@ func (e *Engine) SendRequestSync(r *sdp.ItemRequest) (*sdp.RequestProgress, []*s
 		return progress, items, errors.New("ItemRequest cannot be nil")
 	}
 
+	if e.natsConnection == nil {
+		return progress, items, errors.New("Engine has no NATS connection. Has it been started?")
+	}
+
 	responseSubscription, err = e.natsConnection.Subscribe(r.ResponseSubject, progress.ProcessResponse)
 
 	if err != nil {

--- a/requests.go
+++ b/requests.go
@@ -2,6 +2,8 @@ package discovery
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"sync"
@@ -11,6 +13,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/proto"
 )
 
 // NewItemSubject Generates a random subject name for returning items e.g.
@@ -28,7 +31,7 @@ func NewResponseSubject() string {
 // NewItemRequestHandler Returns a function whose job is to handle a single
 // request. This includes responses, linking etc.
 func (e *Engine) ItemRequestHandler(itemRequest *sdp.ItemRequest) {
-	if len(e.FilterSources(itemRequest.Type, itemRequest.Context)) == 0 {
+	if !e.WillRespond(itemRequest) {
 		// If we don't have any relevant sources, exit
 		return
 	}
@@ -124,53 +127,122 @@ func (e *Engine) ExecuteRequest(ctx context.Context, req *sdp.ItemRequest) ([]*s
 		return nil, ctx.Err()
 	}
 
-	var requestItem *sdp.Item
-	var requestError error
+	items := make(chan *sdp.Item)
+	errors := make(chan error)
+	done := make(chan bool)
+	wg := sync.WaitGroup{}
 
-	requestItems := make([]*sdp.Item, 0)
+	expanded := e.ExpandRequest(req)
 
-	// TODO: Thread safety
-
-	// Make the request of all sources
-	switch req.GetMethod() {
-	case sdp.RequestMethod_GET:
-		requestItem, requestError = e.Get(ctx, req)
-		requestItems = append(requestItems, requestItem)
-	case sdp.RequestMethod_FIND:
-		requestItems, requestError = e.Find(ctx, req)
-	case sdp.RequestMethod_SEARCH:
-		requestItems, requestError = e.Search(ctx, req)
+	if len(expanded) == 0 {
+		return []*sdp.Item{}, &sdp.ItemRequestError{
+			ErrorType:   sdp.ItemRequestError_NOCONTEXT,
+			ErrorString: "No matching sources found",
+			Context:     req.Context,
+		}
 	}
 
-	// If there was an error in the request then simply return
-	if requestError != nil {
-		return nil, sdp.NewItemRequestError(requestError)
+	for request, sources := range expanded {
+		wg.Add(1)
+		go func(r *sdp.ItemRequest, sources []Source) {
+			defer wg.Done()
+			var requestItems []*sdp.Item
+			var requestError error
+
+			// Make the request of all sources
+			switch req.GetMethod() {
+			case sdp.RequestMethod_GET:
+				var requestItem *sdp.Item
+
+				requestItem, requestError = e.Get(ctx, r, sources)
+				requestItems = append(requestItems, requestItem)
+			case sdp.RequestMethod_FIND:
+				requestItems, requestError = e.Find(ctx, r, sources)
+			case sdp.RequestMethod_SEARCH:
+				requestItems, requestError = e.Search(ctx, r, sources)
+			}
+
+			for _, i := range requestItems {
+				// If the main request had a linkDepth of great than zero it means we
+				// need to keep linking, this means that we need to pass down all of the
+				// subject info along with the number of remaining links. If the link
+				// depth is zero then we just pass then back in their normal form as we
+				// won't be executing them
+				if req.GetLinkDepth() > 0 {
+					for _, lir := range i.LinkedItemRequests {
+						lir.LinkDepth = req.LinkDepth - 1
+						lir.ItemSubject = req.ItemSubject
+						lir.ResponseSubject = req.ResponseSubject
+						lir.IgnoreCache = req.IgnoreCache
+						lir.Timeout = req.Timeout
+						lir.UUID = req.UUID
+					}
+				}
+
+				// Assign the item request
+				if i.Metadata != nil {
+					i.Metadata.SourceRequest = req
+				}
+
+				items <- i
+			}
+			errors <- requestError
+		}(request, sources)
 	}
 
-	for _, i := range requestItems {
-		// If the main request had a linkDepth of great than zero it means we
-		// need to keep linking, this means that we need to pass down all of the
-		// subject info along with the number of remaining links. If the link
-		// depth is zero then we just pass then back in their normal form as we
-		// won't be executing them
-		if req.GetLinkDepth() > 0 {
-			for _, lir := range i.LinkedItemRequests {
-				lir.LinkDepth = req.LinkDepth - 1
-				lir.ItemSubject = req.ItemSubject
-				lir.ResponseSubject = req.ResponseSubject
-				lir.IgnoreCache = req.IgnoreCache
-				lir.Timeout = req.Timeout
-				lir.UUID = req.UUID
+	allItems := make([]*sdp.Item, 0)
+	allErrors := make([]error, 0)
+
+	go func() {
+		for item := range items {
+			allItems = append(allItems, item)
+		}
+		done <- true
+	}()
+
+	go func() {
+		for err := range errors {
+			allErrors = append(allErrors, err)
+		}
+		done <- true
+	}()
+
+	// Wait for all requests to complete
+	wg.Wait()
+
+	// Close channels as no more messages are coming
+	close(items)
+	close(errors)
+
+	// Wait for all channels to empty and be added to slices
+	<-done
+	<-done
+
+	// If all failed then return first error
+	if len(allErrors) == len(expanded) && len(allErrors) > 0 {
+		return allItems, allErrors[0]
+	}
+
+	return allItems, nil
+}
+
+// WillRespond Performs a cursory check to see if it's likely that this engine
+// will respond to a given request based on the type and context of teh request.
+// Should be used an initial check before proceeding to detailed processing.
+func (e *Engine) WillRespond(req *sdp.ItemRequest) bool {
+	for _, src := range e.Sources() {
+		typeMatch := (req.Type == src.Type() || IsWildcard(req.Type))
+
+		for _, context := range src.Contexts() {
+			contextMatch := (req.Context == context || IsWildcard(req.Context) || IsWildcard(context))
+
+			if contextMatch && typeMatch {
+				return true
 			}
 		}
-
-		// Assign the item request
-		if i.Metadata != nil {
-			i.Metadata.SourceRequest = req
-		}
 	}
 
-	return requestItems, requestError
+	return false
 }
 
 // ExpandRequest Expands requests with wildcards to no longer contain wildcards.
@@ -183,20 +255,41 @@ func (e *Engine) ExecuteRequest(ctx context.Context, req *sdp.ItemRequest) ([]*s
 // exception to this is if we have a source that supports all contexts, but is
 // unable to list them. In this case there will still be some requests with
 // wildcard contexts as they can't be expanded
-func (e *Engine) ExpandRequest(request *sdp.ItemRequest) []*sdp.ItemRequest {
-	// Filter to just sources that are capable of responding
-	relevantSources := e.FilterSources(request.Type, request.Context)
+//
+// This functions returns a map of requests with the sources that they should be
+// run against
+func (e *Engine) ExpandRequest(request *sdp.ItemRequest) map[*sdp.ItemRequest][]Source {
+	requests := make(map[string]*struct {
+		Request *sdp.ItemRequest
+		Sources []Source
+	})
 
-	requests := make([]*sdp.ItemRequest, 0)
+	var checkSources []Source
 
-	for _, src := range relevantSources {
+	if IsWildcard(request.Type) {
+		// If the request has a wildcard type, all non-hidden sources might try
+		// to respond
+		checkSources = e.NonHiddenSources()
+	} else {
+		// If the type is specific, pull just sources for that type
+		checkSources = e.sourceMap[request.Type]
+	}
+
+	for _, src := range checkSources {
+		// Calculate if the source is hidden
+		var isHidden bool
+
+		if hs, ok := src.(HiddenSource); ok {
+			isHidden = hs.Hidden()
+		}
+
 		for _, sourceContext := range src.Contexts() {
 			// Create a new request if:
 			//
 			// * The source supports all contexts, or
-			// * The request context is a wildcard, or
+			// * The request context is a wildcard (and the source is not hidden), or
 			// * The request context matches source context
-			if IsWildcard(sourceContext) || IsWildcard(request.Context) || sourceContext == request.Context {
+			if IsWildcard(sourceContext) || (IsWildcard(request.Context) && !isHidden) || sourceContext == request.Context {
 				var itemContext string
 
 				// Choose the more specific context
@@ -206,7 +299,7 @@ func (e *Engine) ExpandRequest(request *sdp.ItemRequest) []*sdp.ItemRequest {
 					itemContext = sourceContext
 				}
 
-				requests = append(requests, &sdp.ItemRequest{
+				request := sdp.ItemRequest{
 					Type:            src.Type(),
 					Method:          request.Method,
 					Query:           request.Query,
@@ -214,12 +307,39 @@ func (e *Engine) ExpandRequest(request *sdp.ItemRequest) []*sdp.ItemRequest {
 					ItemSubject:     request.ItemSubject,
 					ResponseSubject: request.ResponseSubject,
 					LinkDepth:       request.LinkDepth,
-				})
+					IgnoreCache:     request.IgnoreCache,
+					UUID:            request.UUID,
+					Timeout:         request.Timeout,
+				}
+
+				hash, err := requestHash(&request)
+
+				if err == nil {
+					if existing, ok := requests[hash]; ok {
+						existing.Sources = append(existing.Sources, src)
+					} else {
+						requests[hash] = &struct {
+							Request *sdp.ItemRequest
+							Sources []Source
+						}{
+							Request: &request,
+							Sources: []Source{
+								src,
+							},
+						}
+					}
+				}
 			}
 		}
 	}
 
-	return requests
+	// Convert back to final map
+	finalMap := make(map[*sdp.ItemRequest][]Source)
+	for _, expanded := range requests {
+		finalMap[expanded.Request] = expanded.Sources
+	}
+
+	return finalMap
 }
 
 // SendRequest Uses the connection to the NATS network that the engine manages
@@ -302,4 +422,19 @@ func (e *Engine) SendRequestSync(r *sdp.ItemRequest) (*sdp.RequestProgress, []*s
 	itemsWG.Wait()
 
 	return progress, items, nil
+}
+
+// requestHash Calculates a hash for a given request which can be used to
+// determine if two requests are identical
+func requestHash(req *sdp.ItemRequest) (string, error) {
+	hash := sha1.New()
+
+	// Marshall to bytes so that we can use sha1 to compare the raw binary
+	b, err := proto.Marshal(req)
+
+	if err != nil {
+		return "", err
+	}
+
+	return base64.URLEncoding.EncodeToString(hash.Sum(b)), nil
 }

--- a/requests_test.go
+++ b/requests_test.go
@@ -346,180 +346,187 @@ func TestExpandRequest(t *testing.T) {
 		Name: "expand-test",
 	}
 
-	// t.Run("with a single source with a single context", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with a single source with a single context", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	simple := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test1",
-	// 		},
-	// 	}
+		simple := TestSource{
+			ReturnContexts: []string{
+				"test1",
+			},
+		}
 
-	// 	e.AddSources(&simple)
+		e.AddSources(&simple)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_GET,
-	// 		Query:   "Debby",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_GET,
+			Query:   "Debby",
+			Context: "*",
+		})
 
-	// 	if expected := 1; len(simple.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, len(simple.GetCalls))
-	// 	}
-	// })
+		if expected := 1; len(simple.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, len(simple.GetCalls))
+		}
+	})
 
-	// t.Run("with a single source with many contexts", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with a single source with many contexts", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	many := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test1",
-	// 			"test2",
-	// 			"test3",
-	// 		},
-	// 	}
+		many := TestSource{
+			ReturnName: "many",
+			ReturnContexts: []string{
+				"test1",
+				"test2",
+				"test3",
+			},
+		}
 
-	// 	e.AddSources(&many)
+		e.AddSources(&many)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_GET,
-	// 		Query:   "Debby",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_GET,
+			Query:   "Debby",
+			Context: "*",
+		})
 
-	// 	if expected := 3; len(many.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, many.GetCalls)
-	// 	}
-	// })
+		if expected := 3; len(many.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, many.GetCalls)
+		}
+	})
 
-	// t.Run("with many sources with single contexts", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with many sources with single contexts", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	sx := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test1",
-	// 		},
-	// 	}
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				"test1",
+			},
+		}
 
-	// 	sy := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test2",
-	// 		},
-	// 	}
+		sy := TestSource{
+			ReturnName: "sy",
+			ReturnContexts: []string{
+				"test2",
+			},
+		}
 
-	// 	e.AddSources(&sx)
-	// 	e.AddSources(&sy)
+		e.AddSources(&sx)
+		e.AddSources(&sy)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_GET,
-	// 		Query:   "Daniel",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_GET,
+			Query:   "Daniel",
+			Context: "*",
+		})
 
-	// 	if expected := 1; len(sx.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
-	// 	}
+		if expected := 1; len(sx.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
+		}
 
-	// 	if expected := 1; len(sy.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
-	// 	}
-	// })
+		if expected := 1; len(sy.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
+		}
+	})
 
-	// t.Run("with many sources with many contexts", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with many sources with many contexts", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	sx := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test1",
-	// 			"test2",
-	// 			"test3",
-	// 		},
-	// 	}
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				"test1",
+				"test2",
+				"test3",
+			},
+		}
 
-	// 	sy := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test4",
-	// 			"test5",
-	// 			"test6",
-	// 		},
-	// 	}
+		sy := TestSource{
+			ReturnName: "sy",
+			ReturnContexts: []string{
+				"test4",
+				"test5",
+				"test6",
+			},
+		}
 
-	// 	e.AddSources(&sx)
-	// 	e.AddSources(&sy)
+		e.AddSources(&sx)
+		e.AddSources(&sy)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_GET,
-	// 		Query:   "Steven",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_GET,
+			Query:   "Steven",
+			Context: "*",
+		})
 
-	// 	if expected := 3; len(sx.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
-	// 	}
+		if expected := 3; len(sx.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
+		}
 
-	// 	if expected := 3; len(sy.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
-	// 	}
-	// })
+		if expected := 3; len(sy.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
+		}
+	})
 
-	// t.Run("with many sources with many contexts which overlap GET", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with many sources with many contexts which overlap GET", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	sx := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test1",
-	// 			"test2",
-	// 			"test3",
-	// 		},
-	// 		ReturnWeight: 10,
-	// 	}
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				"test1",
+				"test2",
+				"test3",
+			},
+			ReturnWeight: 10,
+		}
 
-	// 	sy := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test2",
-	// 			"test3",
-	// 			"test4",
-	// 		},
-	// 		ReturnWeight: 11,
-	// 	}
+		sy := TestSource{
+			ReturnName: "sy",
+			ReturnContexts: []string{
+				"test2",
+				"test3",
+				"test4",
+			},
+			ReturnWeight: 11,
+		}
 
-	// 	e.AddSources(&sx)
-	// 	e.AddSources(&sy)
+		e.AddSources(&sx)
+		e.AddSources(&sy)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_GET,
-	// 		Query:   "Jane",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_GET,
+			Query:   "Jane",
+			Context: "*",
+		})
 
-	// 	if expected := 1; len(sx.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
-	// 	}
+		if expected := 1; len(sx.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
+		}
 
-	// 	if expected := 3; len(sy.GetCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
-	// 	}
-	// })
+		if expected := 3; len(sy.GetCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
+		}
+	})
 
 	t.Run("with many sources with many contexts which overlap FIND", func(t *testing.T) {
 		t.Cleanup(func() {
@@ -564,126 +571,133 @@ func TestExpandRequest(t *testing.T) {
 		}
 	})
 
-	// t.Run("with a single wildcard source", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with a single wildcard source", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	sx := TestSource{
-	// 		ReturnContexts: []string{
-	// 			sdp.WILDCARD,
-	// 		},
-	// 	}
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				sdp.WILDCARD,
+			},
+		}
 
-	// 	e.AddSources(&sx)
+		e.AddSources(&sx)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_FIND,
-	// 		Query:   "Rachel",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_FIND,
+			Query:   "Rachel",
+			Context: "*",
+		})
 
-	// 	if expected := 1; len(sx.FindCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
-	// 	}
-	// })
+		if expected := 1; len(sx.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+		}
+	})
 
-	// t.Run("with a many wildcard sources", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with a many wildcard sources", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	sx := TestSource{
-	// 		ReturnContexts: []string{
-	// 			sdp.WILDCARD,
-	// 		},
-	// 	}
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				sdp.WILDCARD,
+			},
+		}
 
-	// 	sy := TestSource{
-	// 		ReturnContexts: []string{
-	// 			sdp.WILDCARD,
-	// 		},
-	// 	}
+		sy := TestSource{
+			ReturnName: "sy",
+			ReturnContexts: []string{
+				sdp.WILDCARD,
+			},
+		}
 
-	// 	sz := TestSource{
-	// 		ReturnContexts: []string{
-	// 			sdp.WILDCARD,
-	// 		},
-	// 	}
+		sz := TestSource{
+			ReturnName: "sz",
+			ReturnContexts: []string{
+				sdp.WILDCARD,
+			},
+		}
 
-	// 	e.AddSources(&sx)
-	// 	e.AddSources(&sy)
-	// 	e.AddSources(&sz)
+		e.AddSources(&sx)
+		e.AddSources(&sy)
+		e.AddSources(&sz)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_FIND,
-	// 		Query:   "Ross",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_FIND,
+			Query:   "Ross",
+			Context: "*",
+		})
 
-	// 	if expected := 1; len(sx.FindCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
-	// 	}
+		if expected := 1; len(sx.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+		}
 
-	// 	if expected := 1; len(sy.FindCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
-	// 	}
+		if expected := 1; len(sy.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
+		}
 
-	// 	if expected := 1; len(sz.FindCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sz.FindCalls)
-	// 	}
-	// })
+		if expected := 1; len(sz.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sz.FindCalls)
+		}
+	})
 
-	// t.Run("with a many wildcard sources and static sources", func(t *testing.T) {
-	// 	t.Cleanup(func() {
-	// 		e.sourceMap = nil
-	// 		e.ClearCache()
-	// 	})
+	t.Run("with a many wildcard sources and static sources", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
 
-	// 	sx := TestSource{
-	// 		ReturnContexts: []string{
-	// 			sdp.WILDCARD,
-	// 		},
-	// 	}
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				sdp.WILDCARD,
+			},
+		}
 
-	// 	sy := TestSource{
-	// 		ReturnContexts: []string{
-	// 			"test1",
-	// 		},
-	// 	}
+		sy := TestSource{
+			ReturnName: "sy",
+			ReturnContexts: []string{
+				"test1",
+			},
+		}
 
-	// 	// sz := TestSource{
-	// 	// 	ReturnContexts: []string{
-	// 	// 		"test2",
-	// 	// 		"test3",
-	// 	// 	},
-	// 	// }
+		sz := TestSource{
+			ReturnName: "sz",
+			ReturnContexts: []string{
+				"test2",
+				"test3",
+			},
+		}
 
-	// 	e.AddSources(&sx)
-	// 	e.AddSources(&sy)
-	// 	// e.AddSources(&sz)
+		e.AddSources(&sx)
+		e.AddSources(&sy)
+		e.AddSources(&sz)
 
-	// 	e.ItemRequestHandler(&sdp.ItemRequest{
-	// 		Type:    "person",
-	// 		Method:  sdp.RequestMethod_FIND,
-	// 		Query:   "Ross",
-	// 		Context: "*",
-	// 	})
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_FIND,
+			Query:   "Ross",
+			Context: "*",
+		})
 
-	// 	if expected := 1; len(sx.FindCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
-	// 	}
+		if expected := 1; len(sx.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+		}
 
-	// 	if expected := 1; len(sy.FindCalls) != expected {
-	// 		t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
-	// 	}
+		if expected := 1; len(sy.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
+		}
 
-	// 	// if expected := 2; len(sz.FindCalls) != expected {
-	// 	// 	t.Errorf("Expected %v calls, got %v", expected, sz.FindCalls)
-	// 	// }
-	// })
+		if expected := 2; len(sz.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sz.FindCalls)
+		}
+	})
 }

--- a/requests_test.go
+++ b/requests_test.go
@@ -340,3 +340,350 @@ func TestSendRequestSync(t *testing.T) {
 	}
 
 }
+
+func TestExpandRequest(t *testing.T) {
+	e := Engine{
+		Name: "expand-test",
+	}
+
+	// t.Run("with a single source with a single context", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	simple := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test1",
+	// 		},
+	// 	}
+
+	// 	e.AddSources(&simple)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_GET,
+	// 		Query:   "Debby",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 1; len(simple.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, len(simple.GetCalls))
+	// 	}
+	// })
+
+	// t.Run("with a single source with many contexts", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	many := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test1",
+	// 			"test2",
+	// 			"test3",
+	// 		},
+	// 	}
+
+	// 	e.AddSources(&many)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_GET,
+	// 		Query:   "Debby",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 3; len(many.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, many.GetCalls)
+	// 	}
+	// })
+
+	// t.Run("with many sources with single contexts", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	sx := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test1",
+	// 		},
+	// 	}
+
+	// 	sy := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test2",
+	// 		},
+	// 	}
+
+	// 	e.AddSources(&sx)
+	// 	e.AddSources(&sy)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_GET,
+	// 		Query:   "Daniel",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 1; len(sx.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
+	// 	}
+
+	// 	if expected := 1; len(sy.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
+	// 	}
+	// })
+
+	// t.Run("with many sources with many contexts", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	sx := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test1",
+	// 			"test2",
+	// 			"test3",
+	// 		},
+	// 	}
+
+	// 	sy := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test4",
+	// 			"test5",
+	// 			"test6",
+	// 		},
+	// 	}
+
+	// 	e.AddSources(&sx)
+	// 	e.AddSources(&sy)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_GET,
+	// 		Query:   "Steven",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 3; len(sx.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
+	// 	}
+
+	// 	if expected := 3; len(sy.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
+	// 	}
+	// })
+
+	// t.Run("with many sources with many contexts which overlap GET", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	sx := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test1",
+	// 			"test2",
+	// 			"test3",
+	// 		},
+	// 		ReturnWeight: 10,
+	// 	}
+
+	// 	sy := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test2",
+	// 			"test3",
+	// 			"test4",
+	// 		},
+	// 		ReturnWeight: 11,
+	// 	}
+
+	// 	e.AddSources(&sx)
+	// 	e.AddSources(&sy)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_GET,
+	// 		Query:   "Jane",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 1; len(sx.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sx.GetCalls)
+	// 	}
+
+	// 	if expected := 3; len(sy.GetCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sy.GetCalls)
+	// 	}
+	// })
+
+	t.Run("with many sources with many contexts which overlap FIND", func(t *testing.T) {
+		t.Cleanup(func() {
+			e.sourceMap = nil
+			e.ClearCache()
+		})
+
+		sx := TestSource{
+			ReturnName: "sx",
+			ReturnContexts: []string{
+				"test1",
+				"test2",
+				"test3",
+			},
+		}
+
+		sy := TestSource{
+			ReturnName: "sy",
+			ReturnContexts: []string{
+				"test2",
+				"test3",
+				"test4",
+			},
+		}
+
+		e.AddSources(&sx)
+		e.AddSources(&sy)
+
+		e.ItemRequestHandler(&sdp.ItemRequest{
+			Type:    "person",
+			Method:  sdp.RequestMethod_FIND,
+			Query:   "Jane",
+			Context: "*",
+		})
+
+		if expected := 3; len(sx.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+		}
+
+		if expected := 3; len(sy.FindCalls) != expected {
+			t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
+		}
+	})
+
+	// t.Run("with a single wildcard source", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	sx := TestSource{
+	// 		ReturnContexts: []string{
+	// 			sdp.WILDCARD,
+	// 		},
+	// 	}
+
+	// 	e.AddSources(&sx)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_FIND,
+	// 		Query:   "Rachel",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 1; len(sx.FindCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+	// 	}
+	// })
+
+	// t.Run("with a many wildcard sources", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	sx := TestSource{
+	// 		ReturnContexts: []string{
+	// 			sdp.WILDCARD,
+	// 		},
+	// 	}
+
+	// 	sy := TestSource{
+	// 		ReturnContexts: []string{
+	// 			sdp.WILDCARD,
+	// 		},
+	// 	}
+
+	// 	sz := TestSource{
+	// 		ReturnContexts: []string{
+	// 			sdp.WILDCARD,
+	// 		},
+	// 	}
+
+	// 	e.AddSources(&sx)
+	// 	e.AddSources(&sy)
+	// 	e.AddSources(&sz)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_FIND,
+	// 		Query:   "Ross",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 1; len(sx.FindCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+	// 	}
+
+	// 	if expected := 1; len(sy.FindCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
+	// 	}
+
+	// 	if expected := 1; len(sz.FindCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sz.FindCalls)
+	// 	}
+	// })
+
+	// t.Run("with a many wildcard sources and static sources", func(t *testing.T) {
+	// 	t.Cleanup(func() {
+	// 		e.sourceMap = nil
+	// 		e.ClearCache()
+	// 	})
+
+	// 	sx := TestSource{
+	// 		ReturnContexts: []string{
+	// 			sdp.WILDCARD,
+	// 		},
+	// 	}
+
+	// 	sy := TestSource{
+	// 		ReturnContexts: []string{
+	// 			"test1",
+	// 		},
+	// 	}
+
+	// 	// sz := TestSource{
+	// 	// 	ReturnContexts: []string{
+	// 	// 		"test2",
+	// 	// 		"test3",
+	// 	// 	},
+	// 	// }
+
+	// 	e.AddSources(&sx)
+	// 	e.AddSources(&sy)
+	// 	// e.AddSources(&sz)
+
+	// 	e.ItemRequestHandler(&sdp.ItemRequest{
+	// 		Type:    "person",
+	// 		Method:  sdp.RequestMethod_FIND,
+	// 		Query:   "Ross",
+	// 		Context: "*",
+	// 	})
+
+	// 	if expected := 1; len(sx.FindCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sx.FindCalls)
+	// 	}
+
+	// 	if expected := 1; len(sy.FindCalls) != expected {
+	// 		t.Errorf("Expected %v calls, got %v", expected, sy.FindCalls)
+	// 	}
+
+	// 	// if expected := 2; len(sz.FindCalls) != expected {
+	// 	// 	t.Errorf("Expected %v calls, got %v", expected, sz.FindCalls)
+	// 	// }
+	// })
+}

--- a/shared_test.go
+++ b/shared_test.go
@@ -2,6 +2,7 @@ package discovery
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -57,6 +58,8 @@ type TestSource struct {
 	FindCalls      [][]string
 	SearchCalls    [][]string
 	IsHidden       bool
+	ReturnWeight   int
+	ReturnName     string
 	mutex          sync.Mutex
 }
 
@@ -76,7 +79,7 @@ func (s *TestSource) Type() string {
 }
 
 func (s *TestSource) Name() string {
-	return "testSource"
+	return fmt.Sprintf("testSource-%v", s.ReturnName)
 }
 
 func (s *TestSource) DefaultCacheDuration() time.Duration {
@@ -159,5 +162,5 @@ func (s *TestSource) Search(ctx context.Context, itemContext string, query strin
 }
 
 func (s *TestSource) Weight() int {
-	return 10
+	return s.ReturnWeight
 }


### PR DESCRIPTION
Due to the way that request expansion worked, it was common for clients so send many copies of the sam item in response to a query. This has been fixed as well as a refactor of the way that requests are handled within the discovery engine. Should be backwards compatible