### PR TITLE
Added method to clear sources

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -408,6 +408,13 @@ func (e *Engine) ClearCache() {
 	e.cache.Clear()
 }
 
+// ClearSources Deletes all sources from the engine, allowing new sources to be
+// added using `AddSource()`. Note that this requires a restart using
+// `Restart()` in order to take effect
+func (e *Engine) ClearSources() {
+	e.sh.ClearAllSources()
+}
+
 // IsWildcard checks if a string is the wildcard. Use this instead of
 // implementing the wildcard check everywhere so that if we need to change the
 // wildcard at a later date we can do so here

--- a/engine_test.go
+++ b/engine_test.go
@@ -229,6 +229,24 @@ func TestNats(t *testing.T) {
 		}
 	})
 
+	t.Run("Restarting", func(t *testing.T) {
+		err := e.Stop()
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = e.Start()
+
+		if err != nil {
+			t.Error(err)
+		}
+
+		if len(e.subscriptions) != 4 {
+			t.Errorf("Expected engine to have 4 subscriptions, got %v", len(e.subscriptions))
+		}
+	})
+
 	t.Run("Handling a basic query", func(t *testing.T) {
 		t.Cleanup(func() {
 			src.ClearCalls()

--- a/sourcehost.go
+++ b/sourcehost.go
@@ -189,6 +189,14 @@ func (sh *SourceHost) ExpandQuery(q *sdp.Query) map[*sdp.Query][]Source {
 	return finalMap
 }
 
+// ClearAllSources Removes all sources
+func (sh *SourceHost) ClearAllSources() {
+	sh.sourceMapMutex.Lock()
+	defer sh.sourceMapMutex.Unlock()
+
+	sh.sourceMap = make(map[string][]Source)
+}
+
 // queryHash Calculates a hash for a given query which can be used to
 // determine if two queries are identical
 func queryHash(req *sdp.Query) (string, error) {


### PR DESCRIPTION
This means they can be reloaded without restarting an entire source. Though it would be more efficient to hot-swap them one by one, with manual testing this takes < 1s even with 300 namespaces. So this behaviour should be okay for now