### PR TITLE
Refactor the cache to live at the Source level

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on: push
 jobs:
   test:
     name: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8cpu
     strategy:
       matrix:
         # Go only supports 2x revisions at once

--- a/enginerequests.go
+++ b/enginerequests.go
@@ -404,23 +404,28 @@ func (e *Engine) callSources(ctx context.Context, q *sdp.Query, relevantSources 
 
 				if sdpErr, ok := err.(*sdp.QueryError); ok {
 					// Add details if they aren't populated
-					if sdpErr.Scope == "" {
-						sdpErr.Scope = q.Scope
+					scope := sdpErr.Scope
+					if scope == "" {
+						scope = q.Scope
 					}
-					sdpErr.UUID = q.UUID
-					sdpErr.ItemType = src.Type()
-					sdpErr.ResponderName = e.Name
-					sdpErr.SourceName = src.Name()
-
-					errs = append(errs, sdpErr)
+					errs = append(errs, &sdp.QueryError{
+						UUID:          q.UUID,
+						ErrorType:     sdpErr.ErrorType,
+						ErrorString:   sdpErr.ErrorString,
+						Scope:         scope,
+						SourceName:    src.Name(),
+						ItemType:      src.Type(),
+						ResponderName: e.Name,
+					})
 				} else {
 					errs = append(errs, &sdp.QueryError{
-						UUID:        q.UUID,
-						ErrorType:   sdp.QueryError_OTHER,
-						ErrorString: err.Error(),
-						Scope:       q.Scope,
-						SourceName:  src.Name(),
-						ItemType:    q.Type,
+						UUID:          q.UUID,
+						ErrorType:     sdp.QueryError_OTHER,
+						ErrorString:   err.Error(),
+						Scope:         q.Scope,
+						SourceName:    src.Name(),
+						ItemType:      q.Type,
+						ResponderName: e.Name,
 					})
 				}
 			}

--- a/enginerequests.go
+++ b/enginerequests.go
@@ -73,7 +73,7 @@ func (e *Engine) HandleQuery(ctx context.Context, query *sdp.Query) {
 		attribute.String("om.sdp.method", query.Method.String()),
 		attribute.String("om.sdp.query", query.Query),
 		attribute.String("om.sdp.scope", query.Scope),
-		attribute.String("om.sdp.deadline", query.Deadline.String()),
+		attribute.String("om.sdp.deadline", query.Deadline.AsTime().String()),
 		attribute.Bool("om.sdp.deadlineOverridden", deadlineOverride),
 		attribute.Bool("om.sdp.queryIgnoreCache", query.IgnoreCache),
 	)

--- a/go.mod
+++ b/go.mod
@@ -4,39 +4,63 @@ go 1.21
 
 // Direct dependencies of my codebase
 require (
+	github.com/MrAlias/otel-schema-utils v0.2.1-alpha
 	github.com/getsentry/sentry-go v0.23.0
 	github.com/google/uuid v1.3.1
 	github.com/goombaio/namegenerator v0.0.0-20181006234301-989e774b106e
 	github.com/nats-io/nats-server/v2 v2.10.1
 	github.com/nats-io/nats.go v1.30.0
 	github.com/overmindtech/sdp-go v0.49.5
-	github.com/overmindtech/sdpcache v1.5.0
+	github.com/overmindtech/sdpcache v1.6.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/sourcegraph/conc v0.3.0
+	github.com/spf13/viper v1.16.0
+	go.opentelemetry.io/contrib/detectors/aws/ec2 v1.19.0
 	go.opentelemetry.io/otel v1.18.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.18.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.18.0
+	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
+	go.opentelemetry.io/otel/sdk v1.18.0
 	go.opentelemetry.io/otel/trace v1.18.0
 	google.golang.org/protobuf v1.31.0
 )
 
 // Transitive dependencies
 require (
+	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/auth0/go-jwt-middleware/v2 v2.1.0 // indirect
+	github.com/aws/aws-sdk-go v1.45.7 // indirect
 	github.com/bufbuild/connect-go v1.10.0 // indirect
+	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
+	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-jose/go-jose/v3 v3.0.0 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.1.2 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.17.0 // indirect
+	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/minio/highwayhash v1.0.2 // indirect
+	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/nats-io/jwt/v2 v2.5.2 // indirect
 	github.com/nats-io/nkeys v0.4.5 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
 	github.com/overmindtech/api-client v0.14.0 // indirect
+	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/afero v1.9.5 // indirect
+	github.com/spf13/cast v1.5.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.4.2 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.42.0 // indirect
 	go.opentelemetry.io/otel/metric v1.18.0 // indirect
+	go.opentelemetry.io/otel/schema v0.0.5 // indirect
+	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
@@ -45,41 +69,11 @@ require (
 	golang.org/x/text v0.13.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-)
-
-require (
-	github.com/MrAlias/otel-schema-utils v0.2.1-alpha
-	github.com/spf13/viper v1.16.0
-	go.opentelemetry.io/contrib/detectors/aws/ec2 v1.19.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.18.0
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.18.0
-	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.18.0
-	go.opentelemetry.io/otel/sdk v1.18.0
-)
-
-require (
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
-	github.com/aws/aws-sdk-go v1.45.7 // indirect
-	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
-	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0 // indirect
-	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
-	github.com/magiconair/properties v1.8.7 // indirect
-	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.0.8 // indirect
-	github.com/spf13/afero v1.9.5 // indirect
-	github.com/spf13/cast v1.5.1 // indirect
-	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/subosito/gotenv v1.4.2 // indirect
-	go.opentelemetry.io/otel/schema v0.0.5 // indirect
-	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
 	google.golang.org/grpc v1.58.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
+	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/overmindtech/api-client v0.14.0 h1:zXyjJsIeawNqoWv7FqOjwcqgFpLrDYz7l9
 github.com/overmindtech/api-client v0.14.0/go.mod h1:msdkTAQFlvDGOU4tQk2adk2P8j23uaMWkJ9YRX4wGWI=
 github.com/overmindtech/sdp-go v0.49.5 h1:mvmUvnSM6q3PtUaLb+vJxLbq60uQiXGPB2caPaRBQMk=
 github.com/overmindtech/sdp-go v0.49.5/go.mod h1:q2RBDqmPidIQsYa9g/6nqOeJAyM6j3zgxn94GPCJcF8=
-github.com/overmindtech/sdpcache v1.5.0 h1:QzHWQm1KGN9rNHPb/VZvz7WDCsyKOuVLlNUGF2CIFGc=
-github.com/overmindtech/sdpcache v1.5.0/go.mod h1:GFMMle860EWMDQXbk6dhLVSQrV0YlEqqJ6/VNxINb0o=
+github.com/overmindtech/sdpcache v1.6.0 h1:cIaLXULSltDzvf6Me91h70/ZnypiRbROmrJ+ovAGGpo=
+github.com/overmindtech/sdpcache v1.6.0/go.mod h1:SHrj4t9f0x7V3WPYAEf31nukuLSIqg1YeqrSdMwLw8c=
 github.com/pelletier/go-toml/v2 v2.0.8 h1:0ctb6s9mE31h0/lhu+J6OPmVeDxJn+kYnJc2jZR9tGQ=
 github.com/pelletier/go-toml/v2 v2.0.8/go.mod h1:vuYfssBdrU2XDZ9bYydBu6t+6a6PYNcZljzZR9VXg+4=
 github.com/pingcap/errors v0.11.4 h1:lFuQV/oaUMGcD2tqt+01ROSmJs75VG1ToEOkZIZ4nE4=

--- a/meta_sources.go
+++ b/meta_sources.go
@@ -37,7 +37,7 @@ func newTypeItem(typ string) *sdp.Item {
 	}
 }
 
-func (t *TypeSource) Get(ctx context.Context, scope string, query string) (*sdp.Item, error) {
+func (t *TypeSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
 	if scope != "global" {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
@@ -57,7 +57,7 @@ func (t *TypeSource) Get(ctx context.Context, scope string, query string) (*sdp.
 	return newTypeItem(sources[0].Type()), nil
 }
 
-func (t *TypeSource) List(ctx context.Context, scope string) ([]*sdp.Item, error) {
+func (t *TypeSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
 	if scope != "global" {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
@@ -135,7 +135,7 @@ func newScopeItem(scope string) *sdp.Item {
 	}
 }
 
-func (t *ScopeSource) Get(ctx context.Context, scope string, query string) (*sdp.Item, error) {
+func (t *ScopeSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
 	if scope != "global" {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
@@ -157,7 +157,7 @@ func (t *ScopeSource) Get(ctx context.Context, scope string, query string) (*sdp
 	}
 }
 
-func (t *ScopeSource) List(ctx context.Context, scope string) ([]*sdp.Item, error) {
+func (t *ScopeSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
 	if scope != "global" {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
@@ -230,7 +230,7 @@ func (s *SourcesSource) Scopes() []string {
 	return []string{"global"}
 }
 
-func (s *SourcesSource) Get(ctx context.Context, scope string, query string) (*sdp.Item, error) {
+func (s *SourcesSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
 	for _, src := range s.sh.Sources() {
 		if src.Name() == query {
 			return s.sourceToItem(src)
@@ -242,7 +242,7 @@ func (s *SourcesSource) Get(ctx context.Context, scope string, query string) (*s
 	}
 }
 
-func (s *SourcesSource) List(ctx context.Context, scope string) ([]*sdp.Item, error) {
+func (s *SourcesSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
 	sources := s.sh.Sources()
 	items := make([]*sdp.Item, len(sources))
 

--- a/meta_sources_test.go
+++ b/meta_sources_test.go
@@ -23,7 +23,7 @@ func TestTypeSource(t *testing.T) {
 	})
 
 	t.Run("listing types", func(t *testing.T) {
-		items, err := s.List(context.Background(), "global")
+		items, err := s.List(context.Background(), "global", false)
 
 		if err != nil {
 			t.Error(err)
@@ -48,7 +48,7 @@ func TestTypeSource(t *testing.T) {
 	})
 
 	t.Run("get a specific type", func(t *testing.T) {
-		item, err := s.Get(context.Background(), "global", "secret")
+		item, err := s.Get(context.Background(), "global", "secret", false)
 
 		if err != nil {
 			t.Error(err)
@@ -62,7 +62,7 @@ func TestTypeSource(t *testing.T) {
 	})
 
 	t.Run("get a bad type", func(t *testing.T) {
-		_, err := s.Get(context.Background(), "global", "nothing-here")
+		_, err := s.Get(context.Background(), "global", "nothing-here", false)
 
 		if err == nil {
 			t.Error("expected error got nil")
@@ -93,7 +93,7 @@ func TestScopeSource(t *testing.T) {
 	})
 
 	t.Run("listing Scopes", func(t *testing.T) {
-		items, err := s.List(context.Background(), "global")
+		items, err := s.List(context.Background(), "global", false)
 
 		if err != nil {
 			t.Error(err)
@@ -118,7 +118,7 @@ func TestScopeSource(t *testing.T) {
 	})
 
 	t.Run("get a specific Scope", func(t *testing.T) {
-		item, err := s.Get(context.Background(), "global", "secret")
+		item, err := s.Get(context.Background(), "global", "secret", false)
 
 		if err != nil {
 			t.Error(err)
@@ -132,7 +132,7 @@ func TestScopeSource(t *testing.T) {
 	})
 
 	t.Run("get a bad Scope", func(t *testing.T) {
-		_, err := s.Get(context.Background(), "global", "nothing-here")
+		_, err := s.Get(context.Background(), "global", "nothing-here", false)
 
 		if err == nil {
 			t.Error("expected error got nil")

--- a/nats_watcher_test.go
+++ b/nats_watcher_test.go
@@ -82,7 +82,7 @@ func TestNATSWatcher(t *testing.T) {
 		t.Errorf("FailureHandler not called in %v", (interval * 2).String())
 	case <-fail:
 		// The fail handler has been called!
-		t.Log("Fail handler called suucesfully 🥳")
+		t.Log("Fail handler called successfully 🥳")
 	}
 }
 

--- a/performance_test.go
+++ b/performance_test.go
@@ -36,7 +36,7 @@ func (s *SlowSource) Hidden() bool {
 	return false
 }
 
-func (s *SlowSource) Get(ctx context.Context, scope string, query string) (*sdp.Item, error) {
+func (s *SlowSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
 	end := time.Now().Add(s.QueryDuration)
 	attributes, _ := sdp.ToAttributes(map[string]interface{}{
 		"name": query,
@@ -64,7 +64,7 @@ func (s *SlowSource) Get(ctx context.Context, scope string, query string) (*sdp.
 	return &item, nil
 }
 
-func (s *SlowSource) List(ctx context.Context, scope string) ([]*sdp.Item, error) {
+func (s *SlowSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
 	return []*sdp.Item{}, nil
 }
 

--- a/querytracker_test.go
+++ b/querytracker_test.go
@@ -37,7 +37,7 @@ func (s *SpeedTestSource) Scopes() []string {
 	return []string{"test"}
 }
 
-func (s *SpeedTestSource) Get(ctx context.Context, scope string, query string) (*sdp.Item, error) {
+func (s *SpeedTestSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
 	select {
 	case <-time.After(s.QueryDelay):
 		return &sdp.Item{
@@ -76,8 +76,8 @@ func (s *SpeedTestSource) Get(ctx context.Context, scope string, query string) (
 
 }
 
-func (s *SpeedTestSource) List(ctx context.Context, scope string) ([]*sdp.Item, error) {
-	item, err := s.Get(ctx, scope, "dylan")
+func (s *SpeedTestSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
+	item, err := s.Get(ctx, scope, "dylan", ignoreCache)
 
 	return []*sdp.Item{item}, err
 }

--- a/shared_test.go
+++ b/shared_test.go
@@ -105,7 +105,7 @@ func (s *TestSource) Hidden() bool {
 	return s.IsHidden
 }
 
-func (s *TestSource) Get(ctx context.Context, scope string, query string) (*sdp.Item, error) {
+func (s *TestSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
@@ -129,7 +129,7 @@ func (s *TestSource) Get(ctx context.Context, scope string, query string) (*sdp.
 	}
 }
 
-func (s *TestSource) List(ctx context.Context, scope string) ([]*sdp.Item, error) {
+func (s *TestSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 	s.ListCalls = append(s.ListCalls, []string{scope})
@@ -152,7 +152,7 @@ func (s *TestSource) List(ctx context.Context, scope string) ([]*sdp.Item, error
 	}
 }
 
-func (s *TestSource) Search(ctx context.Context, scope string, query string) ([]*sdp.Item, error) {
+func (s *TestSource) Search(ctx context.Context, scope string, query string, ignoreCache bool) ([]*sdp.Item, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 

--- a/shared_test.go
+++ b/shared_test.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/goombaio/namegenerator"
 	"github.com/overmindtech/sdp-go"
+	"github.com/overmindtech/sdpcache"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -32,7 +34,10 @@ func RandomName() string {
 	return fmt.Sprintf("%v-%v", name, randGarbage)
 }
 
+var generation atomic.Int32
+
 func (s *TestSource) NewTestItem(scope string, query string) *sdp.Item {
+	gen := generation.Add(1)
 	return &sdp.Item{
 		Type:            s.Type(),
 		Scope:           scope,
@@ -40,8 +45,9 @@ func (s *TestSource) NewTestItem(scope string, query string) *sdp.Item {
 		Attributes: &sdp.ItemAttributes{
 			AttrStruct: &structpb.Struct{
 				Fields: map[string]*structpb.Value{
-					"name": structpb.NewStringValue(query),
-					"age":  structpb.NewNumberValue(28),
+					"name":       structpb.NewStringValue(query),
+					"age":        structpb.NewNumberValue(28),
+					"generation": structpb.NewNumberValue(float64(gen)),
 				},
 			},
 		},
@@ -68,13 +74,24 @@ type TestSource struct {
 	ReturnWeight int    // Weight to be returned
 	ReturnName   string // The name of the source
 	mutex        sync.Mutex
+
+	CacheDuration time.Duration   // How long to cache items for
+	cache         *sdpcache.Cache // The sdpcache of this source
+	cacheInitMu   sync.Mutex      // Mutex to ensure cache is only initialised once
 }
+
+// assert interface implementation
+var _ CachingSource = (*TestSource)(nil)
 
 // ClearCalls Clears the call counters between tests
 func (s *TestSource) ClearCalls() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	s.ListCalls = make([][]string, 0)
 	s.SearchCalls = make([][]string, 0)
 	s.GetCalls = make([][]string, 0)
+	s.cache.Clear()
 }
 
 func (s *TestSource) Type() string {
@@ -93,6 +110,21 @@ func (s *TestSource) DefaultCacheDuration() time.Duration {
 	return 100 * time.Millisecond
 }
 
+func (s *TestSource) ensureCache() {
+	s.cacheInitMu.Lock()
+	defer s.cacheInitMu.Unlock()
+
+	if s.cache == nil {
+		s.cache = sdpcache.NewCache()
+		s.cache.MinWaitTime = 100 * time.Millisecond
+	}
+}
+
+func (s *TestSource) Cache() *sdpcache.Cache {
+	s.ensureCache()
+	return s.cache
+}
+
 func (s *TestSource) Scopes() []string {
 	if len(s.ReturnScopes) > 0 {
 		return s.ReturnScopes
@@ -109,15 +141,30 @@ func (s *TestSource) Get(ctx context.Context, scope string, query string, ignore
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	s.ensureCache()
+	cacheHit, ck, cachedItems, qErr := s.cache.Lookup(ctx, s.Name(), sdp.QueryMethod_GET, scope, s.Type(), query, ignoreCache)
+	if qErr != nil {
+		return nil, qErr
+	}
+	if cacheHit {
+		if len(cachedItems) > 0 {
+			return cachedItems[0], nil
+		} else {
+			return nil, nil
+		}
+	}
+
 	s.GetCalls = append(s.GetCalls, []string{scope, query})
 
 	switch scope {
 	case "empty":
-		return nil, &sdp.QueryError{
+		err := &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOTFOUND,
-			ErrorString: "not found (test)",
+			ErrorString: "no items found",
 			Scope:       scope,
 		}
+		s.cache.StoreError(err, s.DefaultCacheDuration(), ck)
+		return nil, err
 	case "error":
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_OTHER,
@@ -125,22 +172,36 @@ func (s *TestSource) Get(ctx context.Context, scope string, query string, ignore
 			Scope:       scope,
 		}
 	default:
-		return s.NewTestItem(scope, query), nil
+		item := s.NewTestItem(scope, query)
+		s.cache.StoreItem(item, s.DefaultCacheDuration(), ck)
+		return item, nil
 	}
 }
 
 func (s *TestSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
+
+	s.ensureCache()
+	cacheHit, ck, cachedItems, qErr := s.cache.Lookup(ctx, s.Name(), sdp.QueryMethod_LIST, scope, s.Type(), "", ignoreCache)
+	if qErr != nil {
+		return nil, qErr
+	}
+	if cacheHit {
+		return cachedItems, nil
+	}
+
 	s.ListCalls = append(s.ListCalls, []string{scope})
 
 	switch scope {
 	case "empty":
-		return nil, &sdp.QueryError{
+		err := &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOTFOUND,
 			ErrorString: "no items found",
 			Scope:       scope,
 		}
+		s.cache.StoreError(err, s.DefaultCacheDuration(), ck)
+		return nil, err
 	case "error":
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_OTHER,
@@ -148,7 +209,9 @@ func (s *TestSource) List(ctx context.Context, scope string, ignoreCache bool) (
 			Scope:       scope,
 		}
 	default:
-		return []*sdp.Item{s.NewTestItem(scope, "Dylan")}, nil
+		item := s.NewTestItem(scope, "Dylan")
+		s.cache.StoreItem(item, s.DefaultCacheDuration(), ck)
+		return []*sdp.Item{item}, nil
 	}
 }
 
@@ -156,15 +219,26 @@ func (s *TestSource) Search(ctx context.Context, scope string, query string, ign
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
+	s.ensureCache()
+	cacheHit, ck, cachedItems, qErr := s.cache.Lookup(ctx, s.Name(), sdp.QueryMethod_SEARCH, scope, s.Type(), query, ignoreCache)
+	if qErr != nil {
+		return nil, qErr
+	}
+	if cacheHit {
+		return cachedItems, nil
+	}
+
 	s.SearchCalls = append(s.SearchCalls, []string{scope, query})
 
 	switch scope {
 	case "empty":
-		return nil, &sdp.QueryError{
+		err := &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOTFOUND,
 			ErrorString: "no items found",
 			Scope:       scope,
 		}
+		s.cache.StoreError(err, s.DefaultCacheDuration(), ck)
+		return nil, err
 	case "error":
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_OTHER,
@@ -172,7 +246,9 @@ func (s *TestSource) Search(ctx context.Context, scope string, query string, ign
 			Scope:       scope,
 		}
 	default:
-		return []*sdp.Item{s.NewTestItem(scope, "Dylan")}, nil
+		item := s.NewTestItem(scope, "Dylan")
+		s.cache.StoreItem(item, s.DefaultCacheDuration(), ck)
+		return []*sdp.Item{item}, nil
 	}
 }
 

--- a/source.go
+++ b/source.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/overmindtech/sdp-go"
+	"github.com/overmindtech/sdpcache"
 )
 
 // Source is capable of finding information about items
@@ -41,7 +42,13 @@ type Source interface {
 	Weight() int
 }
 
-// SearchableItemSource Is a source of items that supports searching
+// CachingSource Is a source of items that supports caching
+type CachingSource interface {
+	Source
+	Cache() *sdpcache.Cache
+}
+
+// SearchableSource Is a source of items that supports searching
 type SearchableSource interface {
 	Source
 	// Search executes a specific search and returns zero or many items as a

--- a/source.go
+++ b/source.go
@@ -30,10 +30,10 @@ type Source interface {
 
 	// Get Get a single item with a given scope and query. The item returned
 	// should have a UniqueAttributeValue that matches the `query` parameter.
-	Get(ctx context.Context, scope string, query string) (*sdp.Item, error)
+	Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error)
 
 	// List Lists all items in a given scope
-	List(ctx context.Context, scope string) ([]*sdp.Item, error)
+	List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error)
 
 	// Weight Returns the priority weighting of items returned by this source.
 	// This is used to resolve conflicts where two sources of the same type
@@ -55,7 +55,7 @@ type SearchableSource interface {
 	// result (and optionally an error). The specific format of the query that
 	// needs to be provided to Search is dependant on the source itself as each
 	// source will respond to searches differently
-	Search(ctx context.Context, scope string, query string) ([]*sdp.Item, error)
+	Search(ctx context.Context, scope string, query string, ignoreCache bool) ([]*sdp.Item, error)
 }
 
 // CacheDefiner Some backends may implement the CacheDefiner interface which
@@ -82,25 +82,4 @@ func GetCacheDuration(s Source) time.Duration {
 	}
 
 	return (10 * time.Minute)
-}
-
-type SourceMethod int64
-
-const (
-	Get SourceMethod = iota
-	List
-	Search
-)
-
-func (s SourceMethod) String() string {
-	switch s {
-	case Get:
-		return "Get"
-	case List:
-		return "List"
-	case Search:
-		return "Search"
-	default:
-		return "Unknown"
-	}
 }

--- a/source_test.go
+++ b/source_test.go
@@ -77,20 +77,20 @@ func TestGet(t *testing.T) {
 			if errs[0].ErrorType != sdp.QueryError_NOTFOUND {
 				t.Errorf("expected ErrorType to be %v, got %v", sdp.QueryError_NOTFOUND, errs[0].ErrorType)
 			}
-			if errs[0].ErrorString != "not found (test)" {
-				t.Errorf("expected ErrorString to be %v, got %v", "", errs[0].ErrorString)
+			if errs[0].ErrorString != "no items found" {
+				t.Errorf("expected ErrorString to be '%v', got '%v'", "no items found", errs[0].ErrorString)
 			}
 			if errs[0].Scope != "empty" {
-				t.Errorf("expected Scope to be %v, got %v", "empty", errs[0].Scope)
+				t.Errorf("expected Scope to be '%v', got '%v'", "empty", errs[0].Scope)
 			}
 			if errs[0].SourceName != "testSource-orange" {
-				t.Errorf("expected SourceName to be %v, got %v", "testSource-orange", errs[0].SourceName)
+				t.Errorf("expected SourceName to be '%v', got '%v'", "testSource-orange", errs[0].SourceName)
 			}
 			if errs[0].ItemType != "person" {
-				t.Errorf("expected ItemType to be %v, got %v", "person", errs[0].ItemType)
+				t.Errorf("expected ItemType to be '%v', got '%v'", "person", errs[0].ItemType)
 			}
 			if errs[0].ResponderName != "TestGet" {
-				t.Errorf("expected ResponderName to be %v, got %v", "TestGet", errs[0].ResponderName)
+				t.Errorf("expected ResponderName to be '%v', got '%v'", "TestGet", errs[0].ResponderName)
 			}
 		} else {
 			t.Errorf("expected 1 error, got %v", len(errs))
@@ -106,7 +106,7 @@ func TestGet(t *testing.T) {
 			src.ClearCalls()
 		})
 
-		var finds1 []*sdp.Item
+		var list1 []*sdp.Item
 		var item2 []*sdp.Item
 		var item3 []*sdp.Item
 		var err error
@@ -118,7 +118,7 @@ func TestGet(t *testing.T) {
 			Method: sdp.QueryMethod_GET,
 		}
 
-		finds1, _, err = e.ExecuteQuerySync(context.Background(), &req)
+		list1, _, err = e.ExecuteQuerySync(context.Background(), &req)
 		if err != nil {
 			t.Error(err)
 		}
@@ -129,8 +129,8 @@ func TestGet(t *testing.T) {
 			t.Error(err)
 		}
 
-		if finds1[0].Metadata.Timestamp.String() != item2[0].Metadata.Timestamp.String() {
-			t.Errorf("Get queries 10ms apart had different timestamps, caching not working. %v != %v", finds1[0].Metadata.Timestamp.String(), item2[0].Metadata.Timestamp.String())
+		if list1[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() != item2[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() {
+			t.Errorf("Get queries 10ms apart had different timestamps, caching not working. %v != %v", list1[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue(), item2[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue())
 		}
 
 		time.Sleep(10 * time.Millisecond)
@@ -281,14 +281,14 @@ func TestListSearchCaching(t *testing.T) {
 
 	e := newStartedEngine(t, "TestListSearchCaching", nil, &src)
 
-	t.Run("caching with successful find", func(t *testing.T) {
+	t.Run("caching with successful list", func(t *testing.T) {
 		t.Cleanup(func() {
 			src.ClearCalls()
 		})
 
-		var finds1 []*sdp.Item
-		var finds2 []*sdp.Item
-		var finds3 []*sdp.Item
+		var list1 []*sdp.Item
+		var list2 []*sdp.Item
+		var list3 []*sdp.Item
 		var err error
 		q := sdp.Query{
 			Type:   "person",
@@ -296,7 +296,7 @@ func TestListSearchCaching(t *testing.T) {
 			Method: sdp.QueryMethod_LIST,
 		}
 
-		finds1, _, err = e.ExecuteQuerySync(context.Background(), &q)
+		list1, _, err = e.ExecuteQuerySync(context.Background(), &q)
 
 		if err != nil {
 			t.Error(err)
@@ -304,29 +304,29 @@ func TestListSearchCaching(t *testing.T) {
 
 		time.Sleep(10 * time.Millisecond)
 
-		finds2, _, err = e.ExecuteQuerySync(context.Background(), &q)
+		list2, _, err = e.ExecuteQuerySync(context.Background(), &q)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if finds1[0].Metadata.Timestamp.String() != finds2[0].Metadata.Timestamp.String() {
-			t.Error("List queries 10ms apart had different timestamps, caching not working")
+		if list1[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() != list2[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() {
+			t.Errorf("List queries had different generations, caching not working. %v != %v", list1[0].Attributes.AttrStruct.Fields["generation"], list2[0].Attributes.AttrStruct.Fields["generation"])
 		}
 
 		time.Sleep(10 * time.Millisecond)
 		e.sh.Purge()
 
-		finds3, _, err = e.ExecuteQuerySync(context.Background(), &q)
+		list3, _, err = e.ExecuteQuerySync(context.Background(), &q)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if finds2[0].Metadata.Timestamp.String() == finds3[0].Metadata.Timestamp.String() {
-			t.Error("List queries after purging had the same timestamps, cache not expiring")
+		if list2[0].Attributes.AttrStruct.Fields["generation"] == list3[0].Attributes.AttrStruct.Fields["generation"] {
+			t.Errorf("List queries after purging had the same generation, caching not working. %v == %v", list2[0].Attributes.AttrStruct.Fields["generation"], list3[0].Attributes.AttrStruct.Fields["generation"])
 		}
 	})
 
-	t.Run("empty find", func(t *testing.T) {
+	t.Run("empty list", func(t *testing.T) {
 		t.Cleanup(func() {
 			src.ClearCalls()
 		})
@@ -339,7 +339,6 @@ func TestListSearchCaching(t *testing.T) {
 		}
 
 		_, _, err = e.ExecuteQuerySync(context.Background(), &q)
-
 		if err == nil {
 			t.Error("expected error but got nil")
 		}
@@ -353,7 +352,7 @@ func TestListSearchCaching(t *testing.T) {
 		}
 
 		if l := len(src.ListCalls); l != 1 {
-			t.Errorf("Expected only 1 find call, got %v, cache not working", l)
+			t.Errorf("Expected only 1 list call, got %v, cache not working: %v", l, src.ListCalls)
 		}
 
 		time.Sleep(200 * time.Millisecond)
@@ -365,7 +364,7 @@ func TestListSearchCaching(t *testing.T) {
 		}
 
 		if l := len(src.ListCalls); l != 2 {
-			t.Errorf("Expected 2 find calls, got %v, cache not clearing", l)
+			t.Errorf("Expected 2 list calls, got %v, cache not clearing: %v", l, src.ListCalls)
 		}
 	})
 
@@ -374,9 +373,9 @@ func TestListSearchCaching(t *testing.T) {
 			src.ClearCalls()
 		})
 
-		var finds1 []*sdp.Item
-		var finds2 []*sdp.Item
-		var finds3 []*sdp.Item
+		var list1 []*sdp.Item
+		var list2 []*sdp.Item
+		var list3 []*sdp.Item
 		var err error
 		q := sdp.Query{
 			Type:   "person",
@@ -385,34 +384,31 @@ func TestListSearchCaching(t *testing.T) {
 			Method: sdp.QueryMethod_SEARCH,
 		}
 
-		finds1, _, err = e.ExecuteQuerySync(context.Background(), &q)
-
+		list1, _, err = e.ExecuteQuerySync(context.Background(), &q)
 		if err != nil {
 			t.Error(err)
 		}
 
 		time.Sleep(10 * time.Millisecond)
 
-		finds2, _, err = e.ExecuteQuerySync(context.Background(), &q)
-
+		list2, _, err = e.ExecuteQuerySync(context.Background(), &q)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if finds1[0].Metadata.Timestamp.String() != finds2[0].Metadata.Timestamp.String() {
-			t.Error("List queries 10ms apart had different timestamps, caching not working")
+		if list1[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() != list2[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() {
+			t.Errorf("List queries had different generations, caching not working. %v != %v", list1[0].Attributes.AttrStruct.Fields["generation"], list2[0].Attributes.AttrStruct.Fields["generation"])
 		}
 
 		time.Sleep(200 * time.Millisecond)
 
-		finds3, _, err = e.ExecuteQuerySync(context.Background(), &q)
-
+		list3, _, err = e.ExecuteQuerySync(context.Background(), &q)
 		if err != nil {
 			t.Error(err)
 		}
 
-		if finds2[0].Metadata.Timestamp.String() == finds3[0].Metadata.Timestamp.String() {
-			t.Error("List queries 200ms apart had the same timestamps, cache not expiring")
+		if list2[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() == list3[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() {
+			t.Errorf("List queries 200ms apart had the same generations, caching not working. %v == %v", list2[0].Attributes.AttrStruct.Fields["generation"], list3[0].Attributes.AttrStruct.Fields["generation"])
 		}
 	})
 
@@ -548,8 +544,8 @@ func TestSearchGetCaching(t *testing.T) {
 			Method: sdp.QueryMethod_SEARCH,
 		}
 
+		t.Logf("Searching for %v", q.Query)
 		searchResult, searchErrors, err = e.ExecuteQuerySync(context.Background(), &q)
-
 		if err != nil {
 			t.Error(err)
 		}
@@ -564,12 +560,17 @@ func TestSearchGetCaching(t *testing.T) {
 			t.Fatal("Got no results")
 		}
 
+		if len(searchResult) > 1 {
+			t.Fatalf("Got too many results: %v", searchResult)
+		}
+
 		time.Sleep(10 * time.Millisecond)
 
 		// Do a get query for that same item
 		q.Method = sdp.QueryMethod_GET
 		q.Query = searchResult[0].UniqueAttributeValue()
 
+		t.Logf("Getting %v from cache", q.Query)
 		getResult, getErrors, err = e.ExecuteQuerySync(context.Background(), &q)
 
 		if err != nil {
@@ -586,8 +587,8 @@ func TestSearchGetCaching(t *testing.T) {
 			t.Error("No result from GET")
 		}
 
-		if searchResult[0].Metadata.Timestamp.String() != getResult[0].Metadata.Timestamp.String() {
-			t.Error("Item timestamps do not match, caching has not worked")
+		if searchResult[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() != getResult[0].Attributes.AttrStruct.Fields["generation"].GetNumberValue() {
+			t.Errorf("Search and Get queries had different generations, caching not working. %v != %v", searchResult[0].Attributes.AttrStruct.Fields["generation"], getResult[0].Attributes.AttrStruct.Fields["generation"])
 		}
 	})
 }

--- a/sourcehost.go
+++ b/sourcehost.go
@@ -1,10 +1,12 @@
 package discovery
 
 import (
+	"context"
 	"crypto/sha1"
 	"encoding/base64"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/overmindtech/sdp-go"
@@ -216,4 +218,39 @@ func queryHash(req *sdp.Query) (string, error) {
 	}
 
 	return base64.URLEncoding.EncodeToString(hash.Sum(b)), nil
+}
+
+// StartPurger Starts the purger for all caching sources
+func (sh *SourceHost) StartPurger(ctx context.Context) {
+	for _, s := range sh.Sources() {
+		if c, ok := s.(CachingSource); ok {
+			cache := c.Cache()
+			if cache != nil {
+				cache.StartPurger(ctx)
+			}
+		}
+	}
+}
+
+func (sh *SourceHost) Purge() {
+	for _, s := range sh.Sources() {
+		if c, ok := s.(CachingSource); ok {
+			cache := c.Cache()
+			if cache != nil {
+				cache.Purge(time.Now())
+			}
+		}
+	}
+}
+
+// ClearCaches Clears caches for all caching sources
+func (sh *SourceHost) ClearCaches() {
+	for _, s := range sh.Sources() {
+		if c, ok := s.(CachingSource); ok {
+			cache := c.Cache()
+			if cache != nil {
+				cache.Clear()
+			}
+		}
+	}
 }

--- a/tracing.go
+++ b/tracing.go
@@ -10,7 +10,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.12.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.21.0"
 	"go.opentelemetry.io/otel/trace"
 )
 


### PR DESCRIPTION
After moving the cache bulk of the cache lookup code into sdpcache (see https://github.com/overmindtech/sdpcache/pull/64), this change now shifts the cache into the individual sources. There is a new `CachingSource` interface that provides access to the cache. The SourceHost functions as dispatcher for Start/Stop/Purge at the engine level.

Sources that want caching of their queries need to implement CachingSource and provide a `sdpcache.Cache` instance on request.

All of this is to allow the source to access the cache locally when calling into itself.

Requires https://github.com/overmindtech/sdpcache/pull/64