### PR TITLE
Have sources respond on substring matches of the query scope

### DIFF
--- a/meta_sources.go
+++ b/meta_sources.go
@@ -3,6 +3,7 @@ package discovery
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/overmindtech/sdp-go"
@@ -38,10 +39,10 @@ func newTypeItem(typ string) *sdp.Item {
 }
 
 func (t *TypeSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
-	if scope != "global" {
+	if !strings.Contains("global", scope) {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
-			ErrorString: fmt.Sprintf("%v only available in global scope", t.Type()),
+			ErrorString: fmt.Sprintf("'%v' only available in global scope", t.Type()),
 		}
 	}
 
@@ -50,7 +51,7 @@ func (t *TypeSource) Get(ctx context.Context, scope string, query string, ignore
 	if len(sources) == 0 {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOTFOUND,
-			ErrorString: fmt.Sprintf("scope %v not found", query),
+			ErrorString: fmt.Sprintf("type '%v' not found", query),
 		}
 	}
 
@@ -58,7 +59,7 @@ func (t *TypeSource) Get(ctx context.Context, scope string, query string, ignore
 }
 
 func (t *TypeSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
-	if scope != "global" {
+	if !strings.Contains("global", scope) {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
 			ErrorString: fmt.Sprintf("%v only available in global scope", t.Type()),
@@ -136,7 +137,7 @@ func newScopeItem(scope string) *sdp.Item {
 }
 
 func (t *ScopeSource) Get(ctx context.Context, scope string, query string, ignoreCache bool) (*sdp.Item, error) {
-	if scope != "global" {
+	if !strings.Contains("global", scope) {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
 			ErrorString: fmt.Sprintf("%v only available in global scope", t.Type()),
@@ -153,12 +154,12 @@ func (t *ScopeSource) Get(ctx context.Context, scope string, query string, ignor
 
 	return nil, &sdp.QueryError{
 		ErrorType:   sdp.QueryError_NOTFOUND,
-		ErrorString: fmt.Sprintf("scope %v not found", query),
+		ErrorString: fmt.Sprintf("scope '%v' not found", query),
 	}
 }
 
 func (t *ScopeSource) List(ctx context.Context, scope string, ignoreCache bool) ([]*sdp.Item, error) {
-	if scope != "global" {
+	if !strings.Contains("global", scope) {
 		return nil, &sdp.QueryError{
 			ErrorType:   sdp.QueryError_NOSCOPE,
 			ErrorString: fmt.Sprintf("%v only available in global scope", t.Type()),

--- a/sourcehost.go
+++ b/sourcehost.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha1"
 	"encoding/base64"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -150,8 +151,8 @@ func (sh *SourceHost) ExpandQuery(q *sdp.Query) map[*sdp.Query][]Source {
 			//
 			// * The source supports all scopes, or
 			// * The query scope is a wildcard (and the source is not hidden), or
-			// * The query scope matches source scope
-			if IsWildcard(sourceScope) || (IsWildcard(q.Scope) && !isHidden) || sourceScope == q.Scope {
+			// * The query scope substring matches source scope
+			if IsWildcard(sourceScope) || (IsWildcard(q.Scope) && !isHidden) || strings.Contains(sourceScope, q.Scope) {
 				dest := sdp.Query{}
 				q.Copy(&dest)
 

--- a/sourcehost_test.go
+++ b/sourcehost_test.go
@@ -26,11 +26,11 @@ func (e *ExpectExpand) Validate(t *testing.T, m map[*sdp.Query][]Source) {
 	}
 
 	if e.NumQueries != numQueries {
-		t.Errorf("Expected %v queries, got %v", e.NumQueries, numQueries)
+		t.Errorf("Expected %v queries, got %v: %v", e.NumQueries, numQueries, m)
 	}
 
 	if e.NumSources != numSources {
-		t.Errorf("Expected %v sources, got %v", e.NumSources, numSources)
+		t.Errorf("Expected %v sources, got %v: %v", e.NumSources, numSources, m)
 	}
 }
 
@@ -52,8 +52,8 @@ func TestSourceHostExpandQuery(t *testing.T) {
 		},
 		&TestSource{
 			ReturnScopes: []string{
-				"testA",
-				"testB",
+				"multiA",
+				"multiB",
 			},
 			ReturnType: "chair",
 		},
@@ -109,7 +109,7 @@ func TestSourceHostExpandQuery(t *testing.T) {
 	t.Run("Multi-scope", func(t *testing.T) {
 		req := sdp.Query{
 			Type:  "chair",
-			Scope: "testB",
+			Scope: "multiB",
 		}
 
 		ee := ExpectExpand{
@@ -169,6 +169,20 @@ func TestSourceHostExpandQuery(t *testing.T) {
 		ee := ExpectExpand{
 			NumQueries: 5,
 			NumSources: 5,
+		}
+
+		ee.Validate(t, sh.ExpandQuery(&req))
+	})
+
+	t.Run("substring match", func(t *testing.T) {
+		req := sdp.Query{
+			Type:  sdp.WILDCARD,
+			Scope: "multi",
+		}
+
+		ee := ExpectExpand{
+			NumQueries: 3,
+			NumSources: 3,
 		}
 
 		ee.Validate(t, sh.ExpandQuery(&req))


### PR DESCRIPTION
While this does increase query processing by sources by a tiny bit (due to the wider NATS subscriptions), it is offset by far by the reduced API traffic due to improved granularity when querying.

Fixes: https://github.com/overmindtech/discovery/issues/194