### PR TITLE
Remove in-engine linking

### DIFF
--- a/enginerequests_test.go
+++ b/enginerequests_test.go
@@ -62,11 +62,6 @@ func TestExecuteQuery(t *testing.T) {
 		}
 
 		item := items[0]
-		query := item.LinkedItemQueries[0].Query
-
-		if ld := query.GetRecursionBehaviour().GetLinkDepth(); ld != 2 {
-			t.Errorf("expected linked item depth to be 1 less than the query (2), got %v", ld)
-		}
 
 		if item.Metadata.SourceQuery != q {
 			t.Error("source query mismatch")

--- a/meta_sources_test.go
+++ b/meta_sources_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestTypeSource(t *testing.T) {
 	s := &TypeSource{
-		sh: newTestSourceHost(t),
+		sh: newTestSourceHost(),
 	}
 
 	t.Run("satisfies Source interface", func(t *testing.T) {
@@ -80,7 +80,7 @@ func TestTypeSource(t *testing.T) {
 
 func TestScopeSource(t *testing.T) {
 	s := &ScopeSource{
-		sh: newTestSourceHost(t),
+		sh: newTestSourceHost(),
 	}
 
 	t.Run("satisfies Source interface", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestScopeSource(t *testing.T) {
 	})
 }
 
-func newTestSourceHost(t *testing.T) *SourceHost {
+func newTestSourceHost() *SourceHost {
 	sh := NewSourceHost()
 	sh.AddSources(
 		&TestSource{

--- a/nats_shared_test.go
+++ b/nats_shared_test.go
@@ -28,7 +28,7 @@ func SkipWithoutNats(t *testing.T) {
 	var err error
 
 	for _, url := range NatsTestURLs {
-		err := testURL(url)
+		err = testURL(url)
 
 		if err == nil {
 			return
@@ -46,7 +46,7 @@ func SkipWithoutNatsAuth(t *testing.T) {
 	var err error
 
 	for _, url := range NatsAuthTestURLs {
-		err := testURL(url)
+		err = testURL(url)
 
 		if err == nil {
 			return

--- a/performance_test.go
+++ b/performance_test.go
@@ -87,13 +87,6 @@ func TestParallelQueryPerformance(t *testing.T) {
 		RunLinearPerformanceTest(t, "100 queries", 100, 0, 10)
 		RunLinearPerformanceTest(t, "1,000 queries", 1000, 0, 100)
 	})
-
-	t.Run("With linking", func(t *testing.T) {
-		RunLinearPerformanceTest(t, "1 query 3 depth", 1, 3, 1)
-		RunLinearPerformanceTest(t, "1 query 3 depth", 1, 3, 100)
-		RunLinearPerformanceTest(t, "1 query 5 depth", 1, 5, 100)
-		RunLinearPerformanceTest(t, "10 queries 5 depth", 10, 5, 100)
-	})
 }
 
 // RunLinearPerformanceTest Runs a test with a given number in input queries,

--- a/querytracker.go
+++ b/querytracker.go
@@ -60,7 +60,6 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 			if ok {
 				sdpItems = append(sdpItems, item)
 
-				// Send the fully item back onto the network
 				if qt.Query.Subject() != "" && qt.Engine.natsConnection != nil {
 					// Respond with the Item
 					err := qt.Engine.natsConnection.Publish(ctx, qt.Query.Subject(), &sdp.QueryResponse{

--- a/querytracker.go
+++ b/querytracker.go
@@ -3,11 +3,10 @@ package discovery
 import (
 	"context"
 	"errors"
-	"fmt"
-	"sync"
 
 	"github.com/overmindtech/sdp-go"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // QueryTracker is used for tracking the progress of a single query. This
@@ -23,238 +22,6 @@ type QueryTracker struct {
 
 	// The engine that this is connected to, used for sending NATS messages
 	Engine *Engine
-
-	// Channel of items that have been found but have not yet had their links
-	// resolved
-	unlinkedItems chan *sdp.Item
-	// Waitgroup so we can ensure that nothing is processing before closing the
-	// channel
-	unlinkedItemsWG sync.WaitGroup
-
-	// Items that have begin link processing. Note that items in this map may
-	// still be being modified if the linker is still running. Call
-	// `stopLinking()` before accessing this map to avoid race conditions
-	//
-	// The keys in this map are the GloballyUniqueName to speed up searching
-	linkedItems      map[string]*sdp.Item
-	linkedItemsMutex sync.RWMutex
-}
-
-func (qt *QueryTracker) LinkedItems() []*sdp.Item {
-	qt.linkedItemsMutex.RLock()
-	defer qt.linkedItemsMutex.RUnlock()
-
-	items := make([]*sdp.Item, len(qt.linkedItems))
-	i := 0
-
-	for _, item := range qt.linkedItems {
-		items[i] = item
-		i++
-	}
-
-	return items
-}
-
-// registerLinkedItem Registers an item in the database of linked items,
-// returns an error if the item is already present
-func (qt *QueryTracker) registerLinkedItem(i *sdp.Item) error {
-	qt.linkedItemsMutex.Lock()
-	defer qt.linkedItemsMutex.Unlock()
-
-	if qt.linkedItems == nil {
-		qt.linkedItems = make(map[string]*sdp.Item)
-	}
-
-	if _, exists := qt.linkedItems[i.GloballyUniqueName()]; exists {
-		return fmt.Errorf("item %v has already been registered", i.GloballyUniqueName())
-	}
-
-	qt.linkedItems[i.GloballyUniqueName()] = i
-
-	return nil
-}
-
-// queueUnlinkedItem Adds an item to the queue for linking. The engine will then
-// execute the linked item queries and publish the completed item to the
-// relevant NATS subject. Linking can be started and stopped using
-// `startLinking()` and `stopLinking()`
-func (qt *QueryTracker) queueUnlinkedItem(i *sdp.Item) {
-	if i != nil {
-		qt.unlinkedItemsWG.Add(1)
-		qt.unlinkedItems <- i
-	}
-}
-
-// startLinking Starts linking items that have been added to the queue using
-// `queueUnlinkedItem()`. Once an item is fully linked it will be published to
-// NATS
-func (qt *QueryTracker) startLinking(ctx context.Context) {
-	// Link items
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case unlinkedItem, ok := <-qt.unlinkedItems:
-				if !ok {
-					// Return if the channel is closed
-					return
-				}
-
-				if unlinkedItem != nil {
-					go func(i *sdp.Item) {
-						defer qt.unlinkedItemsWG.Done()
-
-						// Register the item with the handler to ensure that we aren't being called
-						// in a recursive manner. If this fails it means the item has already been
-						// found and we should stop doing what we're doing in order to avoid
-						// duplicates
-						//
-						// Note that we are only storing pointers to the items so we can still edit
-						// them in other goroutines as long as we are locking appropriately to avoid
-						// race conditions
-						if err := qt.registerLinkedItem(i); err != nil {
-							// If the item is already registered that's okay. We just don't want
-							// to continue
-							return
-						}
-
-						var hasSourceQuery bool
-						var natsSubject string
-
-						if metadata := i.GetMetadata(); metadata != nil {
-							if sourceQuery := metadata.GetSourceQuery(); sourceQuery != nil {
-								hasSourceQuery = true
-								natsSubject = sourceQuery.Subject()
-
-								if sourceQuery.RecursionBehaviour.GetLinkDepth() > 0 {
-									// Resolve links
-									qt.linkItem(ctx, i, sourceQuery.RecursionBehaviour.GetFollowOnlyBlastPropagation())
-								}
-							}
-						}
-
-						// Send the fully linked item back onto the network
-						if e := qt.Engine; e != nil && hasSourceQuery {
-							if e.IsNATSConnected() {
-								// Respond with the Item
-								err := e.natsConnection.Publish(ctx, natsSubject, &sdp.QueryResponse{ResponseType: &sdp.QueryResponse_NewItem{NewItem: i}})
-
-								if err != nil {
-									// TODO: I probably shouldn't be logging directly here but I
-									// don't want the error to be lost
-									log.WithFields(log.Fields{
-										"error": err,
-									}).Error("Response publishing error")
-								}
-							}
-						}
-					}(unlinkedItem)
-				}
-			}
-		}
-	}()
-}
-
-// linkItem should run all linkedItemQueries that it can and modify the passed
-// item with the results. Removing any linked item queries that were able to
-// execute
-func (qt *QueryTracker) linkItem(ctx context.Context, parent *sdp.Item, followOnlyBlastPropagation bool) {
-	if ctx.Err() != nil {
-		return
-	}
-
-	var lirWG sync.WaitGroup
-	var itemMutex sync.RWMutex
-
-	// Loop over the linked item queries
-	itemMutex.RLock()
-
-	lirWG.Add(len(parent.LinkedItemQueries))
-
-	for _, lir := range parent.LinkedItemQueries {
-		go func(p *sdp.Item, req *sdp.LinkedItemQuery) {
-			defer lirWG.Done()
-			if followOnlyBlastPropagation && !req.GetBlastPropagation().GetOut() {
-				// skip the LinkedItemQuery if we should follow only blast propagation and the liq does not propagate blast out
-				return
-			}
-
-			if qt.Engine == nil {
-				return
-			}
-
-			items := make(chan *sdp.Item)
-			errs := make(chan *sdp.QueryError)
-			queryErr := make(chan error)
-			var shouldRemove bool
-
-			go func(e chan error) {
-				defer LogRecoverToReturn(ctx, "linkItem -> ExecuteQuery")
-				e <- qt.Engine.ExecuteQuery(ctx, req.Query, items, errs)
-			}(queryErr)
-
-			for {
-				select {
-				case li, ok := <-items:
-					if ok {
-						itemMutex.Lock()
-
-						// Add the new items back into the queue to be linked
-						// further if required
-						qt.queueUnlinkedItem(li)
-
-						// Create a reference to the newly found item and attach
-						// to the parent item
-						p.LinkedItems = append(p.LinkedItems, &sdp.LinkedItem{
-							Item:             li.Reference(),
-							BlastPropagation: req.BlastPropagation,
-						})
-
-						itemMutex.Unlock()
-					} else {
-						items = nil
-					}
-				case err, ok := <-errs:
-					if ok {
-						if err.ErrorType == sdp.QueryError_NOTFOUND {
-							// If we looked and didn't find the item then
-							// there is no point keeping the query around.
-							// Mark as true so that it's removed from the
-							// item
-							shouldRemove = true
-						}
-					} else {
-						errs = nil
-					}
-				}
-
-				if items == nil && errs == nil {
-					break
-				}
-			}
-
-			err := <-queryErr
-
-			if err == nil || shouldRemove {
-				// Delete the item query if we were able to resolve it locally
-				// OR it failed to resolve but because we looked and we know it
-				// doesn't exist
-				itemMutex.Lock()
-				p.LinkedItemQueries = deleteQuery(p.LinkedItemQueries, req)
-				itemMutex.Unlock()
-			}
-		}(parent, lir)
-	}
-	itemMutex.RUnlock()
-
-	lirWG.Wait()
-}
-
-// stopLinking Stop linking items in the queue
-func (qt *QueryTracker) stopLinking() {
-	qt.unlinkedItemsWG.Wait()
-	close(qt.unlinkedItems)
 }
 
 // Execute Executes a given item query and publishes results and errors on the
@@ -264,10 +31,6 @@ func (qt *QueryTracker) stopLinking() {
 //
 // If the context is cancelled, all query work will stop
 func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryError, error) {
-	if qt.unlinkedItems == nil {
-		qt.unlinkedItems = make(chan *sdp.Item)
-	}
-
 	if qt.Query == nil {
 		return nil, nil, nil
 	}
@@ -276,12 +39,13 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 		return nil, nil, errors.New("no engine supplied, cannot execute")
 	}
 
+	span := trace.SpanFromContext(ctx)
+
 	items := make(chan *sdp.Item)
 	errs := make(chan *sdp.QueryError)
 	errChan := make(chan error)
 	sdpErrs := make([]*sdp.QueryError, 0)
-
-	qt.startLinking(ctx)
+	sdpItems := make([]*sdp.Item, 0)
 
 	// Run the query
 	go func(e chan error) {
@@ -294,9 +58,24 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 		select {
 		case item, ok := <-items:
 			if ok {
-				// Add to the queue. This will be picked up by other goroutine,
-				// linked and published to NATS once done
-				qt.queueUnlinkedItem(item)
+				sdpItems = append(sdpItems, item)
+
+				// Send the fully item back onto the network
+				if qt.Query.Subject() != "" && qt.Engine.natsConnection != nil {
+					// Respond with the Item
+					err := qt.Engine.natsConnection.Publish(ctx, qt.Query.Subject(), &sdp.QueryResponse{
+						ResponseType: &sdp.QueryResponse_NewItem{
+							NewItem: item,
+						},
+					})
+
+					if err != nil {
+						span.RecordError(err)
+						log.WithFields(log.Fields{
+							"error": err,
+						}).Error("Response publishing error")
+					}
+				}
 			} else {
 				items = nil
 			}
@@ -304,12 +83,11 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 			if ok {
 				sdpErrs = append(sdpErrs, err)
 
-				if qt.Query.Subject() != "" && qt.Engine.natsConnection.Underlying() != nil {
+				if qt.Query.Subject() != "" && qt.Engine.natsConnection != nil {
 					pubErr := qt.Engine.natsConnection.Publish(ctx, qt.Query.Subject(), &sdp.QueryResponse{ResponseType: &sdp.QueryResponse_Error{Error: err}})
 
 					if pubErr != nil {
-						// TODO: I probably shouldn't be logging directly here but I
-						// don't want the error to be lost
+						span.RecordError(err)
 						log.WithFields(log.Fields{
 							"error": err,
 						}).Error("Error publishing item query error")
@@ -320,7 +98,7 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 			}
 		case <-ctx.Done():
 			// If the context is closed, return an error
-			return qt.LinkedItems(), sdpErrs, ctx.Err()
+			return sdpItems, sdpErrs, ctx.Err()
 		}
 
 		if items == nil && errs == nil {
@@ -330,26 +108,12 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 		}
 	}
 
-	// Wait for all of the initial queries to be done processing
-	qt.stopLinking()
-
 	// Get the result of the execution
 	err := <-errChan
 
 	if err != nil {
-		return qt.LinkedItems(), sdpErrs, err
+		return sdpItems, sdpErrs, err
 	}
 
-	return qt.LinkedItems(), sdpErrs, ctx.Err()
-}
-
-// deleteQuery Deletes an item query from a slice
-func deleteQuery(queries []*sdp.LinkedItemQuery, remove *sdp.LinkedItemQuery) []*sdp.LinkedItemQuery {
-	finalQueries := make([]*sdp.LinkedItemQuery, 0)
-	for _, q := range queries {
-		if q != remove {
-			finalQueries = append(finalQueries, q)
-		}
-	}
-	return finalQueries
+	return sdpItems, sdpErrs, ctx.Err()
 }

--- a/querytracker_test.go
+++ b/querytracker_test.go
@@ -127,37 +127,6 @@ func TestExecute(t *testing.T) {
 		}
 	})
 
-	t.Run("With linking", func(t *testing.T) {
-		t.Parallel()
-
-		qt := QueryTracker{
-			Engine: e,
-			Query: &sdp.Query{
-				Type:   "person",
-				Method: sdp.QueryMethod_GET,
-				Query:  "Dylan",
-				RecursionBehaviour: &sdp.Query_RecursionBehaviour{
-					LinkDepth: 10,
-				},
-				Scope: "test",
-			},
-		}
-
-		items, errs, err := qt.Execute(context.Background())
-
-		if err != nil {
-			t.Error(err)
-		}
-
-		for _, e := range errs {
-			t.Error(e)
-		}
-
-		if l := len(items); l != 11 {
-			t.Errorf("expected 10 items, got %v", l)
-		}
-	})
-
 	t.Run("With no engine", func(t *testing.T) {
 		t.Parallel()
 
@@ -262,41 +231,6 @@ func TestTimeout(t *testing.T) {
 
 		if err == nil {
 			t.Error("Expected timeout but got no error")
-		}
-	})
-
-	t.Run("With linking that exceeds the timeout", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, cancel := context.WithTimeout(context.Background(), 350*time.Millisecond)
-
-		qt := QueryTracker{
-			Engine:  e,
-			Context: ctx,
-			Cancel:  cancel,
-			Query: &sdp.Query{
-				Type:   "person",
-				Method: sdp.QueryMethod_GET,
-				Query:  "somethingElse1",
-				RecursionBehaviour: &sdp.Query_RecursionBehaviour{
-					LinkDepth: 10,
-				},
-				Scope: "test",
-			},
-		}
-
-		items, errs, err := qt.Execute(ctx)
-
-		if err == nil {
-			t.Error("Expected timeout but got no error")
-		}
-
-		for _, e := range errs {
-			t.Error(e)
-		}
-
-		if len(items) != 3 {
-			t.Errorf("Expected 3 items, got %v", len(items))
 		}
 	})
 }


### PR DESCRIPTION
We are having performance issues which I believe is due to the linking inside the engine. Since this is done by the gateway now there is no real reason why this should be done in the engine too