### PR TITLE
Always create a new responder ID for each responder

### DIFF
--- a/enginerequests.go
+++ b/enginerequests.go
@@ -105,10 +105,7 @@ func (e *Engine) HandleQuery(ctx context.Context, query *sdp.Query) {
 		pub = NilConnection{}
 	}
 
-	ru, err := uuid.FromBytes(query.UUID)
-	if err != nil {
-		ru = uuid.New()
-	}
+	ru := uuid.New()
 	responder.Start(
 		ctx,
 		pub,
@@ -128,7 +125,7 @@ func (e *Engine) HandleQuery(ctx context.Context, query *sdp.Query) {
 		defer e.DeleteTrackedQuery(u)
 	}
 
-	_, _, err = qt.Execute(ctx)
+	_, _, err := qt.Execute(ctx)
 
 	// If all failed then return an error
 	if err != nil {


### PR DESCRIPTION
The query UUID was not a great choice as it is still the same across multiple sources for wildcard queries.