### PR TITLE
Add link extraction tool

### DIFF
--- a/link_extract.go
+++ b/link_extract.go
@@ -152,9 +152,5 @@ func isLikelyDNSName(name string) bool {
 	}
 
 	// Check if the name matches the regex pattern.
-	if !dnsNameRegex.MatchString(name) {
-		return false
-	}
-
-	return true
+	return dnsNameRegex.MatchString(name) {
 }

--- a/link_extract.go
+++ b/link_extract.go
@@ -147,7 +147,7 @@ var dnsNameRegex = regexp.MustCompile(`^(?i)([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?\
 // least three labels (sections)
 func isLikelyDNSName(name string) bool {
 	// Quick length check before the regex.
-	if len(name) < 1 || len(name) > 253 {
+	if len(name) < 5 || len(name) > 253 {
 		return false
 	}
 

--- a/link_extract.go
+++ b/link_extract.go
@@ -1,0 +1,178 @@
+package discovery
+
+import (
+	"net"
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/overmindtech/sdp-go"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// This function tries to extract linked item queries from the attributes of an
+// item. It should be on items that we know are likely to contain references
+// that we can discover, but are in an unstructured format which we can't
+// construct the linked item queries from directly. A good example of this would
+// be the env vars for a kubernetes pod, or a config map
+//
+// This supports extracting the following formats:
+//
+// - IP addresses
+// - HTTP/HTTPS URLs
+// - DNS names
+func ExtractLinksFromAttributes(attributes *sdp.ItemAttributes) []*sdp.LinkedItemQuery {
+	return extractLinksFromStructValue(attributes.GetAttrStruct())
+}
+
+func extractLinksFromValue(value *structpb.Value) []*sdp.LinkedItemQuery {
+	switch value.GetKind().(type) {
+	case *structpb.Value_NullValue:
+		return nil
+	case *structpb.Value_NumberValue:
+		return nil
+	case *structpb.Value_StringValue:
+		return extractLinksFromStringValue(value.GetStringValue())
+	case *structpb.Value_BoolValue:
+		return nil
+	case *structpb.Value_StructValue:
+		return extractLinksFromStructValue(value.GetStructValue())
+	case *structpb.Value_ListValue:
+		return extractLinksFromListValue(value.GetListValue())
+	}
+
+	return nil
+}
+
+func extractLinksFromStructValue(structValue *structpb.Struct) []*sdp.LinkedItemQuery {
+	queries := make([]*sdp.LinkedItemQuery, 0)
+
+	for _, value := range structValue.GetFields() {
+		queries = append(queries, extractLinksFromValue(value)...)
+	}
+
+	return queries
+}
+
+func extractLinksFromListValue(list *structpb.ListValue) []*sdp.LinkedItemQuery {
+	queries := make([]*sdp.LinkedItemQuery, 0)
+
+	for _, value := range list.GetValues() {
+		queries = append(queries, extractLinksFromValue(value)...)
+	}
+
+	return queries
+}
+
+// This function does all the heavy lifting for extracting linked item queries
+// from strings. It will be called once for every string value in the item so
+// needs to be very performant
+func extractLinksFromStringValue(val string) []*sdp.LinkedItemQuery {
+	if ip := net.ParseIP(val); ip != nil {
+		return []*sdp.LinkedItemQuery{
+			{
+				Query: &sdp.Query{
+					Type:   "ip",
+					Method: sdp.QueryMethod_GET,
+					Query:  ip.String(),
+					Scope:  "global",
+				},
+				BlastPropagation: &sdp.BlastPropagation{
+					In:  true,
+					Out: true,
+				},
+			},
+		}
+	}
+
+	if parsed, err := url.Parse(val); err == nil {
+		if parsed.Scheme == "" || parsed.Host == "" {
+			// If there's no scheme, we can't do anything with it
+			return nil
+		}
+
+		// If it's a HTTP/HTTPS URL, we can use a HTTP query
+		if parsed.Scheme == "http" || parsed.Scheme == "https" {
+			return []*sdp.LinkedItemQuery{
+				{
+					Query: &sdp.Query{
+						Type:   "http",
+						Method: sdp.QueryMethod_GET,
+						Query:  val,
+						Scope:  "global",
+					},
+					BlastPropagation: &sdp.BlastPropagation{
+						// If we are referencing a HTTP URL, I think it's safe
+						// to assume that this is something that the current
+						// resource depends on and therefore that the blast
+						// radius should propagate inwards. This is a bit of a
+						// guess though...
+						In:  true,
+						Out: false,
+					},
+				},
+			}
+		} else {
+			// If it's not a HTTP/HTTPS URL, it'll be an IP or DNS name, so pass
+			// back to the main function
+			return extractLinksFromStringValue(parsed.Hostname())
+		}
+	}
+
+	if isLikelyDNSName(val) {
+		return []*sdp.LinkedItemQuery{
+			{
+				Query: &sdp.Query{
+					Type:   "dns",
+					Method: sdp.QueryMethod_SEARCH,
+					Query:  val,
+					Scope:  "global",
+				},
+				BlastPropagation: &sdp.BlastPropagation{
+					In:  true,
+					Out: false,
+				},
+			},
+		}
+	}
+
+	return nil
+}
+
+var (
+	// Compile a regex pattern to match the general structure of a DNS name.
+	// Limits each label to 1-63 characters and matches only allowed characters.
+	dnsNameRegex = regexp.MustCompile(`^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
+)
+
+// This function returns true if the given string is a valid DNS name with at
+// least three labels (sections)
+func isLikelyDNSName(name string) bool {
+	// Quick length check before the regex.
+	if len(name) < 1 || len(name) > 253 {
+		return false
+	}
+
+	// Check if the name matches the regex pattern.
+	if !dnsNameRegex.MatchString(name) {
+		return false
+	}
+
+	// Split the name into labels by dot.
+	labels := strings.Split(name, ".")
+
+	if len(labels) < 3 {
+		// We don't want to match names with less than 3 labels since they
+		// aren't likely to be real DNS names
+		return false
+	}
+
+	for _, label := range labels {
+		// Each label must be between 1 and 63 characters.
+		if len(label) < 1 || len(label) > 63 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/link_extract.go
+++ b/link_extract.go
@@ -4,7 +4,6 @@ import (
 	"net"
 	"net/url"
 	"regexp"
-	"strings"
 
 	"github.com/overmindtech/sdp-go"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -139,11 +138,10 @@ func extractLinksFromStringValue(val string) []*sdp.LinkedItemQuery {
 	return nil
 }
 
-var (
-	// Compile a regex pattern to match the general structure of a DNS name.
-	// Limits each label to 1-63 characters and matches only allowed characters.
-	dnsNameRegex = regexp.MustCompile(`^(?i)[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
-)
+// Compile a regex pattern to match the general structure of a DNS name. Limits
+// each label to 1-63 characters and matches only allowed characters and ensure
+// that the name has at least three sections i.e. two dots.
+var dnsNameRegex = regexp.MustCompile(`^(?i)([a-z0-9]([-a-z0-9]{0,61}[a-z0-9])?\.){2,}[a-z]{2,}$`)
 
 // This function returns true if the given string is a valid DNS name with at
 // least three labels (sections)
@@ -156,22 +154,6 @@ func isLikelyDNSName(name string) bool {
 	// Check if the name matches the regex pattern.
 	if !dnsNameRegex.MatchString(name) {
 		return false
-	}
-
-	// Split the name into labels by dot.
-	labels := strings.Split(name, ".")
-
-	if len(labels) < 3 {
-		// We don't want to match names with less than 3 labels since they
-		// aren't likely to be real DNS names
-		return false
-	}
-
-	for _, label := range labels {
-		// Each label must be between 1 and 63 characters.
-		if len(label) < 1 || len(label) > 63 {
-			return false
-		}
 	}
 
 	return true

--- a/link_extract_test.go
+++ b/link_extract_test.go
@@ -417,8 +417,8 @@ version: 5
 	return attrs
 }
 
-// BenchmarkExtractLinksFromAttributes-10    	    6944	    159392 ns/op	  124056 B/op	    1694 allocs/op
-// BenchmarkExtractLinksFromAttributes-10    	   10000	    102911 ns/op	   53291 B/op	     622 allocs/op
+// Current performance:
+// BenchmarkExtractLinksFromAttributes-10    	   12098	     98305 ns/op	   53266 B/op	     621 allocs/op
 func BenchmarkExtractLinksFromAttributes(b *testing.B) {
 	attrs := createTestData()
 

--- a/link_extract_test.go
+++ b/link_extract_test.go
@@ -1,0 +1,438 @@
+package discovery
+
+import (
+	"testing"
+
+	"github.com/overmindtech/sdp-go"
+	"gopkg.in/yaml.v3"
+)
+
+// Create a very large set of attributes for the benchmark
+func createTestData() *sdp.ItemAttributes {
+	yamlString := `---
+creationTimestamp: 2024-07-09T11:16:31Z
+data:
+  AUTH0_AUDIENCE: https://api.example.com
+  AUTH0_DOMAIN: domain.eu.auth0.com
+  AUTH_COOKIE_NAME: overmind_app_access_token
+  GATEWAY_CLIENT_ID: 1234567890
+  GATEWAY_CORS_ALLOW_ORIGINS: https://app.example.com https://*.app.example.com
+  GATEWAY_OVERMIND_AUTH_URL: https://domain.eu.auth0.com/oauth/token
+  GATEWAY_OVERMIND_TOKEN_API: http://service:8080/api
+  GATEWAY_PGDBNAME: user
+  GATEWAY_PGHOST: name.cluster-id.eu-west-2.rds.amazonaws.com
+  GATEWAY_PGPORT: "5432"
+  GATEWAY_PGUSER: user
+  GATEWAY_RUN_MODE: release
+  GATEWAY_SERVICE_PORT: "8080"
+  LOG: info
+immutable: false
+name: foo-config
+namespace: default
+resourceVersion: "167230088"
+uid: c1c1be5e-e11e-46da-8ef4-ce243fe7056e
+generateName: 49731160-e407-4148-bd4d-e00b8eb56cd2-5b76f5987b-
+labels:
+  app: test
+  config-hash: 2be88ca42
+  pod-template-hash: 5b76f5987b
+  source: 49731160-e407-4148-bd4d-e00b8eb56cd2
+spec:
+  containers:
+    - env:
+        - name: NATS_SERVERS
+          value: nats://[fdb4:5627:96ee::bfa3]:4222
+        - name: NATS_NAME_PREFIX
+          value: source.default
+        - name: SERVICE_PORT
+          value: "8080"
+        - name: NATS_JWT
+          valueFrom:
+            secretKeyRef:
+              key: jwt
+              name: 49731160-e407-4148-bd4d-e00b8eb56cd2-nats-auth
+        - name: NATS_NKEY_SEED
+          valueFrom:
+            secretKeyRef:
+              key: nkeySeed
+              name: 49731160-e407-4148-bd4d-e00b8eb56cd2-nats-auth
+        - name: NATS_CA_FILE
+          value: /etc/srcman/certs/ca.pem
+      envFrom:
+        - secretRef:
+            name: prod-tracing-secrets
+      image: ghcr.io/example/example:main
+      imagePullPolicy: Always
+      name: 49731160-e407-4148-bd4d-e00b8eb56cd2
+      readinessProbe:
+        failureThreshold: 3
+        httpGet:
+          path: healthz
+          port: 8080
+          scheme: HTTP
+        periodSeconds: 10
+        successThreshold: 1
+        timeoutSeconds: 1
+      resources: {}
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /etc/srcman/config
+          name: source-config
+          readOnly: true
+        - mountPath: /etc/srcman/certs
+          name: nats-certs
+          readOnly: true
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-vjgp7
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  enableServiceLinks: true
+  nodeName: ip-10-0-4-118.eu-west-2.compute.internal
+  preemptionPolicy: PreemptLowerPriority
+  priority: 0
+  restartPolicy: Always
+  schedulerName: default-scheduler
+  securityContext: {}
+  serviceAccount: default
+  serviceAccountName: default
+  terminationGracePeriodSeconds: 30
+  tolerations:
+    - effect: NoExecute
+      key: node.kubernetes.io/not-ready
+      operator: Exists
+      tolerationSeconds: 300
+    - effect: NoExecute
+      key: node.kubernetes.io/unreachable
+      operator: Exists
+      tolerationSeconds: 300
+  volumes:
+    - configMap:
+        defaultMode: 420
+        name: 49731160-e407-4148-bd4d-e00b8eb56cd2
+      name: source-config
+    - configMap:
+        defaultMode: 420
+        name: prod-ca
+      name: nats-certs
+    - name: kube-api-access-vjgp7
+      projected:
+        defaultMode: 420
+        sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+                - key: ca.crt
+                  path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+status:
+  conditions:
+    - lastTransitionTime: 2024-08-22T13:42:26Z
+      status: "True"
+      type: Initialized
+    - lastTransitionTime: 2024-08-22T13:43:17Z
+      status: "True"
+      type: Ready
+    - lastTransitionTime: 2024-08-22T13:43:17Z
+      status: "True"
+      type: ContainersReady
+    - lastTransitionTime: 2024-08-22T13:42:26Z
+      status: "True"
+      type: PodScheduled
+  containerStatuses:
+    - containerID: containerd://6274579a84ea3bee8cb9bd68092f4ccd6fff13852c1e5c09672c8b3489f3c082
+      image: ghcr.io/example/example:main
+      imageID: ghcr.io/example/example@sha256:c3fd0767e82105e9127267bda3bdb77f51a9e6fbeb79d20c4d25ae0a71876719
+      lastState: {}
+      name: 49731160-e407-4148-bd4d-e00b8eb56cd2
+      ready: true
+      restartCount: 0
+      started: true
+      state:
+        running:
+          startedAt: 2024-08-22T13:42:32Z
+  hostIP: 2a05:d01c:40:7600::6c81
+  phase: Running
+  podIP: 2a05:d01c:40:7600:fbac::3
+  podIPs:
+    - ip: 2a05:d01c:40:7600:fbac::3
+  qosClass: BestEffort
+  startTime: 2024-08-22T13:42:26Z
+code:
+  location: https://awslambda-eu-west-2-tasks.s3.eu-west-2.amazonaws.com/snapshots/123456789/ingress_log-dd9f17f1-0694-4e79-9855-300a7f9b7300?versionId=sxmueRdM4S.HXwlebzlb7rOpD2ZHmS3Z&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEIn%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCWV1LXdlc3QtMiJGMEQCIBWNIrhNoAqNUG%2BoZLmKNSxY9ncDogcyFTGeJFef0zVMAiBhkAW9JWxVna%2FoCXe4u9S3364dCavXEvZP%2FXcD6iwfISq7BQiR%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F8BEAUaDDQ3MjAzODg2NDE4OC
+  repositoryType: S3
+configuration:
+  architectures:
+    - x86_64
+  codeSha256: JxWQc4FaGuW8503fcWt5S2Ua+HHpIX2z2SMhyo/gzBU=
+  codeSize: 7586073
+  description: Parses LB access logs from S3, sending them to Honeycomb as structured events
+  environment:
+    variables:
+      APIHOST: https://api.honeycomb.io
+      DATASET: ingress
+      ENVIRONMENT: ""
+      FILTERFIELDS: ""
+      FORCEGUNZIP: "true"
+      HONEYCOMBWRITEKEY: foobar
+      KMSKEYID: ""
+      PARSERTYPE: alb
+      RENAMEFIELDS: ""
+      SAMPLERATE: "1"
+      SAMPLERATERULES: "[]"
+  ephemeralStorage:
+    size: 512
+  functionArn: arn:aws:lambda:eu-west-2:123456789:function:ingress_log
+  functionName: ingress_log
+  handler: s3-handler
+  lastModified: 2024-05-10T14:33:45.279+0000
+  lastUpdateStatus: Successful
+  lastUpdateStatusReasonCode: ""
+  loggingConfig:
+    applicationLogLevel: ""
+    logFormat: Text
+    logGroup: /aws/lambda/ingress_log
+    systemLogLevel: ""
+  memorySize: 192
+  packageType: Zip
+  revisionId: 876d6948-2e4c-41e0-9a62-d9be8a6a59f5
+  role: arn:aws:iam::123456789:role/ingress_log
+  runtime: provided.al2
+  runtimeVersionConfig:
+    runtimeVersionArn: arn:aws:lambda:eu-west-2::runtime:f4d7a18770044f40f09a49471782a2a42431d746fcfb30bf1cadeda985858aa0
+  snapStart:
+    applyOn: None
+    optimizationStatus: Off
+  state: Active
+  stateReasonCode: ""
+  timeout: 600
+  tracingConfig:
+    mode: PassThrough
+  version: $LATEST
+tags:
+  honeycombAgentless: "true"
+  terraform: "true"
+capacityProviderStrategy:
+  - base: 0
+    capacityProvider: FARGATE
+    weight: 100
+clusterArn: arn:aws:ecs:eu-west-2:123456789:cluster/example-tfc
+createdAt: 2024-08-01T16:06:18.906Z
+createdBy: arn:aws:iam::123456789:role/terraform-example
+deploymentConfiguration:
+  deploymentCircuitBreaker:
+    enable: false
+    rollback: false
+  maximumPercent: 200
+  minimumHealthyPercent: 100
+deploymentController:
+  type: ECS
+deployments:
+  - capacityProviderStrategy:
+      - base: 0
+        capacityProvider: FARGATE
+        weight: 100
+    createdAt: 2024-08-01T16:42:08.6Z
+    desiredCount: 1
+    failedTasks: 0
+    id: ecs-svc/5699741454300708027
+    launchType: ""
+    networkConfiguration:
+      awsvpcConfiguration:
+        assignPublicIp: DISABLED
+        securityGroups:
+          - sg-0826c8494b61cac1f
+        subnets:
+          - subnet-0a393cf4c844bf32d
+          - subnet-0fafe900a3dc4ba78
+    pendingCount: 0
+    platformFamily: Linux
+    platformVersion: 1.4.0
+    rolloutState: COMPLETED
+    rolloutStateReason: ECS deployment ecs-svc/5699741454300708027 completed.
+    runningCount: 1
+    status: PRIMARY
+    taskDefinition: arn:aws:ecs:eu-west-2:123456789:task-definition/facial-recognition-tfc:1
+    updatedAt: 2024-08-01T17:20:11.853Z
+desiredCount: 1
+enableECSManagedTags: false
+enableExecuteCommand: false
+events:
+  - createdAt: 2024-08-01T16:37:45.222Z
+    id: f8240f68-73d0-497f-bf8e-4cb5185bd76c
+    message: "(service facial-recognition) has started 1 tasks: (task
+      d0fd4b687ebf4c968482a9814e1de455)."
+  - createdAt: 2024-08-22T15:50:56.905Z
+    id: 769e21aa-7a70-4270-88b9-55f902ddb727
+    message: (service facial-recognition) has reached a steady state.
+healthCheckGracePeriodSeconds: 0
+launchType: ""
+loadBalancers:
+  - containerName: facial-recognition
+    containerPort: 1234
+    targetGroupArn: arn:aws:elasticloadbalancing:eu-west-2:123456789:targetgroup/facerec-tfc/0b6a17c7de07be40
+networkConfiguration:
+  awsvpcConfiguration:
+    assignPublicIp: DISABLED
+    securityGroups:
+      - sg-0826c8494b61cac1f
+    subnets:
+      - subnet-0a393cf4c844bf32d
+      - subnet-0fafe900a3dc4ba78
+pendingCount: 0
+placementConstraints: []
+placementStrategy: []
+platformFamily: Linux
+platformVersion: LATEST
+propagateTags: NONE
+roleArn: arn:aws:iam::123456789:role/aws-service-role/ecs.amazonaws.com/AWSServiceRoleForECS
+runningCount: 1
+schedulingStrategy: REPLICA
+serviceArn: arn:aws:ecs:eu-west-2:123456789:service/example-tfc/facial-recognition
+serviceFullName: service/example-tfc/facial-recognition
+serviceName: facial-recognition
+serviceRegistries: []
+taskDefinition: arn:aws:ecs:eu-west-2:123456789:task-definition/facial-recognition-tfc:1
+taskSets: []
+compatibilities:
+  - EC2
+  - FARGATE
+containerDefinitions:
+  - cpu: 1024
+    environment: []
+    essential: true
+    healthCheck:
+      command:
+        - CMD-SHELL
+        - wget -q --spider localhost:1234
+      interval: 30
+      retries: 3
+      timeout: 5
+    image: harshmanvar/face-detection-tensorjs:slim-amd
+    memory: 2048
+    mountPoints: []
+    name: facial-recognition
+    portMappings:
+      - appProtocol: http
+        containerPort: 1234
+        hostPort: 1234
+        protocol: tcp
+    systemControls: []
+    volumesFrom: []
+cpu: "1024"
+family: facial-recognition-tfc
+ipcMode: ""
+memory: "2048"
+networkMode: awsvpc
+pidMode: ""
+registeredAt: 2024-08-01T15:27:30.781Z
+registeredBy: arn:aws:sts::123456789:assumed-role/terraform-example/terraform-run-nKsGeEsVUcxfxEuY
+requiresAttributes:
+  - name: com.amazonaws.ecs.capability.docker-remote-api.1.18
+    targetType: ""
+  - name: com.amazonaws.ecs.capability.docker-remote-api.1.24
+    targetType: ""
+  - name: ecs.capability.container-health-check
+    targetType: ""
+  - name: ecs.capability.task-eni
+    targetType: ""
+requiresCompatibilities:
+  - FARGATE
+revision: 1
+taskDefinitionArn: arn:aws:ecs:eu-west-2:123456789:task-definition/facial-recognition-tfc:1
+volumes: []
+attachments:
+  - details:
+      - name: macAddress
+        value: 0a:98:2a:a1:8c:cd
+      - name: networkInterfaceId
+        value: eni-0c99da7dff9025194
+      - name: privateDnsName
+        value: ip-10-0-2-101.eu-west-2.compute.internal
+      - name: privateIPv4Address
+        value: 10.0.2.101
+      - name: subnetId
+        value: subnet-0fafe900a3dc4ba78
+    id: f2dc881c-d3c5-49ca-904e-30358f1675d8
+    status: ATTACHED
+    type: ElasticNetworkInterface
+attributes:
+  - name: ecs.cpu-architecture
+    targetType: ""
+    value: x86_64
+availabilityZone: eu-west-2b
+capacityProviderName: FARGATE
+connectivity: CONNECTED
+connectivityAt: 2024-08-01T17:16:34.995Z
+containers:
+  - containerArn: arn:aws:ecs:eu-west-2:123456789:container/example-tfc/ded4f8eebe4144ddb9a93a27b5661008/778778dd-3a31-44f0-a84f-42a2e75403d9
+    cpu: "1024"
+    healthStatus: HEALTHY
+    image: harshmanvar/face-detection-tensorjs:slim-amd
+    imageDigest: sha256:a12d885a6d05efa01735e5dd60b2580eece2f21d962e38b9bbdf8cfeb81c6894
+    lastStatus: RUNNING
+    memory: "2048"
+    name: facial-recognition
+    networkBindings: []
+    networkInterfaces:
+      - attachmentId: f2dc881c-d3c5-49ca-904e-30358f1675d8
+        privateIpv4Address: 10.0.2.101
+    runtimeId: ded4f8eebe4144ddb9a93a27b5661008-4091029319
+    taskArn: arn:aws:ecs:eu-west-2:123456789:task/example-tfc/ded4f8eebe4144ddb9a93a27b5661008
+desiredStatus: RUNNING
+ephemeralStorage:
+  sizeInGiB: 20
+fargateEphemeralStorage:
+  sizeInGiB: 20
+group: service:facial-recognition
+healthStatus: HEALTHY
+id: example-tfc/ded4f8eebe4144ddb9a93a27b5661008
+lastStatus: RUNNING
+overrides:
+  containerOverrides:
+    - name: facial-recognition
+  inferenceAcceleratorOverrides: []
+pullStartedAt: 2024-08-01T17:18:22.901Z
+pullStoppedAt: 2024-08-01T17:18:34.827Z
+startedAt: 2024-08-01T17:18:48.139Z
+startedBy: ecs-svc/5699741454300708027
+stopCode: ""
+taskArn: arn:aws:ecs:eu-west-2:123456789:task/example-tfc/ded4f8eebe4144ddb9a93a27b5661008
+version: 5
+`
+
+	mapData := make(map[string]interface{})
+	_ = yaml.Unmarshal([]byte(yamlString), &mapData)
+
+	attrs, _ := sdp.ToAttributes(mapData)
+
+	return attrs
+}
+
+// BenchmarkExtractLinksFromAttributes-10    	    6944	    159392 ns/op	  124056 B/op	    1694 allocs/op
+// BenchmarkExtractLinksFromAttributes-10    	   10000	    102911 ns/op	   53291 B/op	     622 allocs/op
+func BenchmarkExtractLinksFromAttributes(b *testing.B) {
+	attrs := createTestData()
+
+	for i := 0; i < b.N; i++ {
+		ExtractLinksFromAttributes(attrs)
+	}
+}
+
+func TestExtractLinksFromAttributes(t *testing.T) {
+	attrs := createTestData()
+
+	queries := ExtractLinksFromAttributes(attrs)
+
+	if len(queries) != 11 {
+		t.Errorf("Expected 11 queries, got %d", len(queries))
+	}
+}


### PR DESCRIPTION
This creates a tool that can extract links from attributes. The plan is that we can use this on items that we know will have unstructured content that includes things we should be linking to. A good example of this is a Kubernetes Pod which will have a number of env vars that are likely to contain URLs etc that Overmind should be able to link on.

I'm not 100% convinced this is the correct implementation though. For example if we run this against a `Pod` it'll extract more than just the stuff from the env vars, which probably isn't what we want. It might be better to pass an `interface{}` or something like that so that we can pass in just the section that we want to know about? The problem with that is that we'll have to pass it through JSON or use a bunch of reflection...