### PR TITLE
Set the UUID before we send the first heartbeat

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -123,7 +123,6 @@ type Engine struct {
 	// stop when the context is cancelled
 	backgroundJobContext context.Context
 	backgroundJobCancel  context.CancelFunc
-	heartbeatContext     context.Context
 	heartbeatCancel      context.CancelFunc
 }
 

--- a/engine.go
+++ b/engine.go
@@ -301,14 +301,14 @@ func (e *Engine) Start() error {
 
 	e.backgroundJobContext, e.backgroundJobCancel = context.WithCancel(context.Background())
 
-	// Start background jobs
-	e.sh.StartPurger(e.backgroundJobContext)
-	e.StartSendingHeartbeats(e.backgroundJobContext)
-
 	// Decide your own UUID if not provided
 	if e.UUID == uuid.Nil {
 		e.UUID = uuid.New()
 	}
+
+	// Start background jobs
+	e.sh.StartPurger(e.backgroundJobContext)
+	e.StartSendingHeartbeats(e.backgroundJobContext)
 
 	return e.connect()
 }

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -90,6 +90,10 @@ func (e *Engine) SendHeartbeat(ctx context.Context) error {
 //
 // If this is called multiple times, nothing will happen. Heartbeats will be
 // stopped when the engine is stopped, or when the provided context is canceled.
+//
+// This will send one heartbeat initially when the method is called, and will
+// then run in a background goroutine that sends heartbeats at the specified
+// frequency, and will stop when the provided context is canceled.
 func (e *Engine) StartSendingHeartbeats(ctx context.Context) {
 	if e.HeartbeatOptions == nil || e.HeartbeatOptions.Frequency == 0 || e.heartbeatCancel != nil {
 		return
@@ -101,7 +105,7 @@ func (e *Engine) StartSendingHeartbeats(ctx context.Context) {
 	// Send one heartbeat at the beginning
 	err := e.SendHeartbeat(heartbeatContext)
 	if err != nil {
-		log.WithError(err).Error("Failed to send initial heartbeat")
+		log.WithError(err).Error("Failed to send heartbeat")
 	}
 
 	go func() {

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -161,13 +161,14 @@ func TestHeartbeats(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 
-		e.StartSendingHeartbeats(ctx)
-
 		start := time.Now()
-		// Get one
+
 		responses <- &connect.Response[sdp.SubmitSourceHeartbeatResponse]{
 			Msg: &sdp.SubmitSourceHeartbeatResponse{},
 		}
+		e.StartSendingHeartbeats(ctx)
+
+		// Get the initial heartbeat
 		<-requests
 
 		// Get two
@@ -179,11 +180,11 @@ func TestHeartbeats(t *testing.T) {
 		cancel()
 
 		// Make sure that took the expected amount of time
-		if elapsed := time.Since(start); elapsed < time.Millisecond*500 {
+		if elapsed := time.Since(start); elapsed < time.Millisecond*250 {
 			t.Errorf("expected to take at least 500ms, took %v", elapsed)
 		}
 
-		if elapsed := time.Since(start); elapsed > time.Millisecond*750 {
+		if elapsed := time.Since(start); elapsed > time.Millisecond*500 {
 			t.Errorf("expected to take at most 750ms, took %v", elapsed)
 		}
 	})


### PR DESCRIPTION
This means that if you don't set an engine's UUID, the first request will still have one