### PR TITLE
(maint) add engine commandline helpers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,11 @@ jobs:
       - name: Go vet
         run: go vet ./...
 
+      - name: find deadcode
+        run: |
+          go install golang.org/x/tools/cmd/deadcode@latest
+          deadcode . | tee out && [ ! -s out ]
+
       # get .golangci.yml from github.com/overmindtech/golangci-lint_config
       - name: Get .golangci.yml from github.com/overmindtech/golangci-lint_configs
         run: |

--- a/adapter_test.go
+++ b/adapter_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func TestEngineAddAdapters(t *testing.T) {
-	e, err := NewEngine()
+	ec := EngineConfig{}
+	e, err := NewEngine(&ec)
 	if err != nil {
 		t.Fatalf("Error initializing Engine: %v", err)
 	}

--- a/cmd.go
+++ b/cmd.go
@@ -1,0 +1,81 @@
+package discovery
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+func AddEngineFlags(command *cobra.Command) {
+	command.PersistentFlags().String("source-name", "", "The name of the source")
+	cobra.CheckErr(viper.BindEnv("source-name", "SOURCE_NAME"))
+	command.PersistentFlags().String("source-uuid", "", "The UUID of the source, is this is blank it will be auto-generated. This is used in heartbeats and shouldn't be supplied usually")
+	cobra.CheckErr(viper.BindEnv("source-uuid", "SOURCE_UUID"))
+	command.PersistentFlags().String("app", "https://app.overmind.tech", "The URL of the Overmind app to use")
+	cobra.CheckErr(viper.BindEnv("app", "APP"))
+	command.PersistentFlags().String("api-key", "", "The API key to use to authenticate to the Overmind API")
+	cobra.CheckErr(viper.BindEnv("api-key", "OVM_API_KEY", "API_KEY"))
+	command.PersistentFlags().Int("max-parallel", 0, "The maximum number of parallel executions")
+	cobra.CheckErr(viper.BindEnv("max-parallel", "MAX_PARALLEL"))
+}
+
+func EngineConfigFromViper(engineType, version string) (*EngineConfig, error) {
+	sourceUUIDString := viper.GetString("source-uuid")
+	var sourceUUID uuid.UUID
+	if sourceUUIDString == "" {
+		sourceUUID = uuid.New()
+	} else {
+		var err error
+		sourceUUID, err = uuid.Parse(sourceUUIDString)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing source-uuid: %w", err)
+		}
+	}
+	maxParallelExecutions := viper.GetInt("max-parallel")
+	if maxParallelExecutions == 0 {
+		maxParallelExecutions = runtime.NumCPU()
+	}
+	var sourceName string
+	if viper.GetString("source-name") == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return nil, fmt.Errorf("error getting hostname: %w", err)
+		}
+		sourceName = fmt.Sprintf("%s-%s", engineType, hostname)
+	} else {
+		sourceName = viper.GetString("source-name")
+	}
+	return &EngineConfig{
+		EngineType:            engineType,
+		Version:               version,
+		SourceName:            sourceName,
+		SourceUUID:            sourceUUID,
+		App:                   viper.GetString("app"),
+		ApiKey:                viper.GetString("api-key"),
+		MaxParallelExecutions: maxParallelExecutions,
+	}, nil
+}
+
+// MapFromEngineConfig Returns the config as a map
+func MapFromEngineConfig(c *EngineConfig) map[string]any {
+
+	var apiKeyClientSecret string
+
+	if c.ApiKey != "" {
+		apiKeyClientSecret = "[REDACTED]"
+	}
+
+	return map[string]interface{}{
+		"engine-type":             c.EngineType,
+		"version":                 c.Version,
+		"source-name":             c.SourceName,
+		"source-uuid":             c.SourceUUID,
+		"app":                     c.App,
+		"api-key":                 apiKeyClientSecret,
+		"max-parallel-executions": c.MaxParallelExecutions,
+	}
+}

--- a/cmd_test.go
+++ b/cmd_test.go
@@ -1,0 +1,103 @@
+package discovery
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEngineConfigFromViper(t *testing.T) {
+	tests := []struct {
+		name                string
+		setupViper          func()
+		engineType          string
+		version             string
+		expectedSourceName  string
+		expectedSourceUUID  uuid.UUID
+		expectedApp         string
+		expectedApiKey      string
+		expectedMaxParallel int
+		expectError         bool
+	}{
+		{
+			name: "default values",
+			setupViper: func() {
+				viper.Reset()
+				viper.Set("app", "https://app.overmind.tech")
+			},
+			engineType:          "test-engine",
+			version:             "1.0",
+			expectedSourceName:  "test-engine-" + getHostname(t),
+			expectedSourceUUID:  uuid.Nil,
+			expectedApp:         "https://app.overmind.tech",
+			expectedApiKey:      "",
+			expectedMaxParallel: runtime.NumCPU(),
+			expectError:         false,
+		},
+		{
+			name: "custom values",
+			setupViper: func() {
+				viper.Reset()
+				viper.Set("source-name", "custom-source")
+				viper.Set("source-uuid", "123e4567-e89b-12d3-a456-426614174000")
+				viper.Set("app", "https://custom.app")
+				viper.Set("api-key", "custom-api-key")
+				viper.Set("max-parallel", 10)
+			},
+			engineType:          "test-engine",
+			version:             "1.0",
+			expectedSourceName:  "custom-source",
+			expectedSourceUUID:  uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"),
+			expectedApp:         "https://custom.app",
+			expectedApiKey:      "custom-api-key",
+			expectedMaxParallel: 10,
+			expectError:         false,
+		},
+		{
+			name: "invalid UUID",
+			setupViper: func() {
+				viper.Reset()
+				viper.Set("source-uuid", "invalid-uuid")
+			},
+			engineType:  "test-engine",
+			version:     "1.0",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupViper()
+			config, err := EngineConfigFromViper(tt.engineType, tt.version)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.engineType, config.EngineType)
+				assert.Equal(t, tt.version, config.Version)
+				assert.Equal(t, tt.expectedSourceName, config.SourceName)
+				if tt.expectedSourceUUID == uuid.Nil {
+					assert.NotEqual(t, uuid.Nil, config.SourceUUID)
+				} else {
+					assert.Equal(t, tt.expectedSourceUUID, config.SourceUUID)
+				}
+				assert.Equal(t, tt.expectedApp, config.App)
+				assert.Equal(t, tt.expectedApiKey, config.ApiKey)
+				assert.Equal(t, tt.expectedMaxParallel, config.MaxParallelExecutions)
+			}
+		})
+	}
+}
+
+func getHostname(t *testing.T) string {
+	hostname, err := os.Hostname()
+	if err != nil {
+		t.Fatalf("error getting hostname: %v", err)
+	}
+	return hostname
+}

--- a/engine_test.go
+++ b/engine_test.go
@@ -18,11 +18,14 @@ import (
 )
 
 func newStartedEngine(t *testing.T, name string, no *auth.NATSOptions, adapters ...Adapter) *Engine {
-	e, err := NewEngine()
+	ec := EngineConfig{
+		MaxParallelExecutions: 10,
+		SourceName:            name,
+	}
+	e, err := NewEngine(&ec)
 	if err != nil {
 		t.Fatalf("Error initializing Engine: %v", err)
 	}
-	e.Name = name
 	if no != nil {
 		e.NATSOptions = no
 	} else {
@@ -37,7 +40,6 @@ func newStartedEngine(t *testing.T, name string, no *auth.NATSOptions, adapters 
 		}
 	}
 	e.NATSQueueName = "test"
-	e.MaxParallelExecutions = 10
 
 	e.AddAdapters(adapters...)
 
@@ -170,11 +172,15 @@ func TestDeleteTrackedQuery(t *testing.T) {
 func TestNats(t *testing.T) {
 	SkipWithoutNats(t)
 
-	e, err := NewEngine()
+	ec := EngineConfig{
+		MaxParallelExecutions: 10,
+		SourceName:            "nats-test",
+	}
+
+	e, err := NewEngine(&ec)
 	if err != nil {
 		t.Fatalf("Error initializing Engine: %v", err)
 	}
-	e.Name = "nats-test"
 	e.NATSOptions = &auth.NATSOptions{
 		NumRetries:        5,
 		RetryDelay:        time.Second,
@@ -184,7 +190,6 @@ func TestNats(t *testing.T) {
 		MaxReconnects:     5,
 	}
 	e.NATSQueueName = "test"
-	e.MaxParallelExecutions = 10
 
 	adapter := TestAdapter{}
 
@@ -266,11 +271,14 @@ func TestNats(t *testing.T) {
 func TestNatsCancel(t *testing.T) {
 	SkipWithoutNats(t)
 
-	e, err := NewEngine()
+	ec := EngineConfig{
+		MaxParallelExecutions: 1,
+		SourceName:            "nats-test",
+	}
+	e, err := NewEngine(&ec)
 	if err != nil {
 		t.Fatalf("Error initializing Engine: %v", err)
 	}
-	e.Name = "nats-test"
 	e.NATSOptions = &auth.NATSOptions{
 		NumRetries:        5,
 		RetryDelay:        time.Second,
@@ -280,7 +288,6 @@ func TestNatsCancel(t *testing.T) {
 		MaxReconnects:     5,
 	}
 	e.NATSQueueName = "test"
-	e.MaxParallelExecutions = 1
 
 	adapter := SpeedTestAdapter{
 		QueryDelay:   2 * time.Second,
@@ -354,11 +361,14 @@ func TestNatsCancel(t *testing.T) {
 
 func TestNatsConnections(t *testing.T) {
 	t.Run("with a bad hostname", func(t *testing.T) {
-		e, err := NewEngine()
+		ec := EngineConfig{
+			MaxParallelExecutions: 1,
+			SourceName:            "nats-test",
+		}
+		e, err := NewEngine(&ec)
 		if err != nil {
 			t.Fatalf("Error initializing Engine: %v", err)
 		}
-		e.Name = "nats-test"
 		e.NATSOptions = &auth.NATSOptions{
 			Servers:           []string{"nats://bad.server"},
 			ConnectionName:    "test-disconnection",
@@ -366,7 +376,6 @@ func TestNatsConnections(t *testing.T) {
 			MaxReconnects:     1,
 		}
 		e.NATSQueueName = "test"
-		e.MaxParallelExecutions = 1
 
 		err = e.Start()
 
@@ -392,11 +401,14 @@ func TestNatsConnections(t *testing.T) {
 			}
 		})
 
-		e, err := NewEngine()
+		ec := EngineConfig{
+			MaxParallelExecutions: 1,
+			SourceName:            "nats-test",
+		}
+		e, err := NewEngine(&ec)
 		if err != nil {
 			t.Fatalf("Error initializing Engine: %v", err)
 		}
-		e.Name = "nats-test"
 		e.NATSOptions = &auth.NATSOptions{
 			NumRetries:        5,
 			RetryDelay:        time.Second,
@@ -408,7 +420,6 @@ func TestNatsConnections(t *testing.T) {
 			ReconnectJitter:   time.Second,
 		}
 		e.NATSQueueName = "test"
-		e.MaxParallelExecutions = 1
 
 		err = e.Start()
 
@@ -457,11 +468,14 @@ func TestNatsConnections(t *testing.T) {
 		// Need to change this to avoid port clashes in github actions
 		opts.Port = 4112
 
-		e, err := NewEngine()
+		ec := EngineConfig{
+			MaxParallelExecutions: 1,
+			SourceName:            "nats-test",
+		}
+		e, err := NewEngine(&ec)
 		if err != nil {
 			t.Fatalf("Error initializing Engine: %v", err)
 		}
-		e.Name = "nats-test"
 		e.NATSOptions = &auth.NATSOptions{
 			NumRetries:        10,
 			RetryDelay:        time.Second,
@@ -473,7 +487,6 @@ func TestNatsConnections(t *testing.T) {
 			ReconnectJitter:   time.Second,
 		}
 		e.NATSQueueName = "test"
-		e.MaxParallelExecutions = 1
 
 		var s *server.Server
 
@@ -510,11 +523,15 @@ func TestNATSFailureRestart(t *testing.T) {
 		t.Fatal("Could not start goroutine NATS server")
 	}
 
-	e, err := NewEngine()
+	ec := EngineConfig{
+		MaxParallelExecutions: 1,
+		SourceName:            "nats-test",
+	}
+	e, err := NewEngine(&ec)
 	if err != nil {
 		t.Fatalf("Error initializing Engine: %v", err)
 	}
-	e.Name = "nats-test"
+
 	e.NATSOptions = &auth.NATSOptions{
 		NumRetries:        10,
 		RetryDelay:        time.Second,
@@ -526,7 +543,6 @@ func TestNATSFailureRestart(t *testing.T) {
 		ReconnectJitter:   10 * time.Millisecond,
 	}
 	e.NATSQueueName = "test"
-	e.MaxParallelExecutions = 1
 	e.ConnectionWatchInterval = 1 * time.Second
 
 	// Connect successfully
@@ -572,11 +588,15 @@ func TestNATSFailureRestart(t *testing.T) {
 func TestNatsAuth(t *testing.T) {
 	SkipWithoutNatsAuth(t)
 
-	e, err := NewEngine()
+	ec := EngineConfig{
+		MaxParallelExecutions: 1,
+		SourceName:            "nats-test",
+	}
+	e, err := NewEngine(&ec)
 	if err != nil {
 		t.Fatalf("Error initializing Engine: %v", err)
 	}
-	e.Name = "nats-test"
+
 	e.NATSOptions = &auth.NATSOptions{
 		NumRetries:        5,
 		RetryDelay:        time.Second,
@@ -587,7 +607,6 @@ func TestNatsAuth(t *testing.T) {
 		TokenClient:       GetTestOAuthTokenClient(t, "org_hdeUXbB55sMMvJLa"),
 	}
 	e.NATSQueueName = "test"
-	e.MaxParallelExecutions = 10
 
 	adapter := TestAdapter{}
 
@@ -649,7 +668,8 @@ func TestNatsAuth(t *testing.T) {
 
 func TestSetupMaxQueryTimeout(t *testing.T) {
 	t.Run("with no value", func(t *testing.T) {
-		e, err := NewEngine()
+		ec := EngineConfig{}
+		e, err := NewEngine(&ec)
 		if err != nil {
 			t.Fatalf("Error initializing Engine: %v", err)
 		}
@@ -660,7 +680,8 @@ func TestSetupMaxQueryTimeout(t *testing.T) {
 	})
 
 	t.Run("with a value", func(t *testing.T) {
-		e, err := NewEngine()
+		ec := EngineConfig{}
+		e, err := NewEngine(&ec)
 		if err != nil {
 			t.Fatalf("Error initializing Engine: %v", err)
 		}

--- a/enginerequests.go
+++ b/enginerequests.go
@@ -109,7 +109,7 @@ func (e *Engine) HandleQuery(ctx context.Context, query *sdp.Query) {
 	responder.Start(
 		ctx,
 		pub,
-		e.Name,
+		e.EngineConfig.SourceName,
 		ru,
 	)
 
@@ -325,7 +325,7 @@ func (e *Engine) callAdapters(ctx context.Context, q *sdp.Query, relevantAdapter
 				ErrorType:     sdp.QueryError_OTHER,
 				ErrorString:   ctx.Err().Error(),
 				Scope:         q.GetScope(),
-				ResponderName: e.Name,
+				ResponderName: e.EngineConfig.SourceName,
 				ItemType:      q.GetType(),
 			},
 		}
@@ -442,7 +442,7 @@ func (e *Engine) callAdapters(ctx context.Context, q *sdp.Query, relevantAdapter
 						Scope:         scope,
 						SourceName:    adapter.Name(),
 						ItemType:      adapter.Type(),
-						ResponderName: e.Name,
+						ResponderName: e.EngineConfig.SourceName,
 					})
 				} else {
 					errs = append(errs, &sdp.QueryError{
@@ -452,7 +452,7 @@ func (e *Engine) callAdapters(ctx context.Context, q *sdp.Query, relevantAdapter
 						Scope:         q.GetScope(),
 						SourceName:    adapter.Name(),
 						ItemType:      q.GetType(),
-						ResponderName: e.Name,
+						ResponderName: e.EngineConfig.SourceName,
 					})
 				}
 			}

--- a/heartbeat.go
+++ b/heartbeat.go
@@ -36,8 +36,8 @@ func (e *Engine) SendHeartbeat(ctx context.Context) error {
 
 	var engineUUID []byte
 
-	if e.UUID != uuid.Nil {
-		engineUUID = e.UUID[:]
+	if e.EngineConfig.SourceUUID != uuid.Nil {
+		engineUUID = e.EngineConfig.SourceUUID[:]
 	}
 
 	// Get available types and scopes
@@ -63,9 +63,9 @@ func (e *Engine) SendHeartbeat(ctx context.Context) error {
 	_, err := e.HeartbeatOptions.ManagementClient.SubmitSourceHeartbeat(ctx, &connect.Request[sdp.SubmitSourceHeartbeatRequest]{
 		Msg: &sdp.SubmitSourceHeartbeatRequest{
 			UUID:             engineUUID,
-			Version:          e.Version,
-			Name:             e.Name,
-			Type:             e.Type,
+			Version:          e.EngineConfig.Version,
+			Name:             e.EngineConfig.SourceName,
+			Type:             e.EngineConfig.EngineType,
 			AvailableScopes:  availableScopes,
 			AdapterMetadata:  adapterMetadata,
 			Managed:          e.Managed,

--- a/heartbeat_test.go
+++ b/heartbeat_test.go
@@ -32,11 +32,14 @@ func TestHeartbeats(t *testing.T) {
 	requests := make(chan *connect.Request[sdp.SubmitSourceHeartbeatRequest], 1)
 	responses := make(chan *connect.Response[sdp.SubmitSourceHeartbeatResponse], 1)
 
-	e, _ := NewEngine()
-	e.Name = name
-	e.UUID = u
-	e.Version = version
-	e.Type = engineType
+	ec := EngineConfig{
+		SourceName: name,
+		SourceUUID: u,
+		Version:    version,
+		EngineType: engineType,
+	}
+	e, _ := NewEngine(&ec)
+
 	e.Managed = sdp.SourceManaged_LOCAL
 	e.HeartbeatOptions = &HeartbeatOptions{
 		ManagementClient: testHeartbeatClient{

--- a/performance_test.go
+++ b/performance_test.go
@@ -122,11 +122,13 @@ type TimedResults struct {
 }
 
 func TimeQueries(numQueries int, linkDepth int, numParallel int) TimedResults {
-	e, err := NewEngine()
+	ec := EngineConfig{
+		MaxParallelExecutions: numParallel,
+	}
+	e, err := NewEngine(&ec)
 	if err != nil {
 		panic(fmt.Sprintf("Error initializing Engine: %v", err))
 	}
-	e.MaxParallelExecutions = numParallel
 	e.AddAdapters(&SlowAdapter{
 		QueryDuration: 100 * time.Millisecond,
 	})


### PR DESCRIPTION
part of https://github.com/overmindtech/discovery/issues/360
implments https://github.com/overmindtech/workspace/issues/139

tested with 
```
    {
            "name": "Launch stdlib-source",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${workspaceFolder}/stdlib-source/main.go",
            "args": [
                "start",
                "--source-name",
                "stupid",
                "--source-uuid",
                "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
                "--app",
                "www.stupid.com",
                "--api-key",
                "123456",
                "--max-parallel",
                "1000000"
            ]
        },
```
and 
```
        {
            "name": "Launch stdlib-source",
            "type": "go",
            "request": "launch",
            "mode": "debug",
            "program": "${workspaceFolder}/stdlib-source/main.go",
            "args": [
                "start"
            ],
            "env": {
                "SOURCE_NAME": "stupid",
                "SOURCE_UUID":              "f81d4fae-7dec-11d0-a765-00a0c91e6bf6",
                "APP": "www.stupid.com",
                "API_KEY": "123456",
                "MAX_PARALLEL": "10",
            }
        },
```