### PR TITLE
Don't exit when the context is cancelled

### DIFF
--- a/enginerequests.go
+++ b/enginerequests.go
@@ -342,6 +342,11 @@ func (e *Engine) ExecuteQuery(ctx context.Context, query *sdp.Query, items chan<
 		}()
 	}
 
+	// If the context is cancelled, return that error
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	// If all failed then return first error
 	if numAdaptersInt := numAdapters.Load(); numErrs == int(numAdaptersInt) {
 		return AllAdaptersFailedError{

--- a/querytracker.go
+++ b/querytracker.go
@@ -95,9 +95,6 @@ func (qt *QueryTracker) Execute(ctx context.Context) ([]*sdp.Item, []*sdp.QueryE
 			} else {
 				errs = nil
 			}
-		case <-ctx.Done():
-			// If the context is closed, return an error
-			return sdpItems, sdpErrs, ctx.Err()
 		}
 
 		if items == nil && errs == nil {


### PR DESCRIPTION
If we do this, it means we close the goroutine that receives on the `errChan` which leaves deadlocked goroutines hanging around forever